### PR TITLE
On-click sort-by-column in load profile trace window

### DIFF
--- a/src/ProfileExplorerUI/Windows/ProfileLoadWindow.xaml
+++ b/src/ProfileExplorerUI/Windows/ProfileLoadWindow.xaml
@@ -631,7 +631,7 @@
                     <GridViewColumn
                       Width="150"
                       DisplayMemberBinding="{Binding Process.Name}">
-                      <GridViewColumnHeader Content="Process" />
+                      <GridViewColumnHeader Name="ProcessNameColumn" Content="Process" />
                       <GridViewColumn.HeaderContainerStyle>
                         <Style TargetType="{x:Type GridViewColumnHeader}">
                           <Setter Property="HorizontalContentAlignment" Value="Left" />
@@ -642,7 +642,7 @@
                     <GridViewColumn
                       Width="80"
                       DisplayMemberBinding="{Binding WeightPercentage, StringFormat={}{0:#0.00'%'}}">
-                      <GridViewColumnHeader Content="Weight" />
+                      <GridViewColumnHeader Name="WeightPercentageColumn" Content="Weight" />
                       <GridViewColumn.HeaderContainerStyle>
                         <Style TargetType="{x:Type GridViewColumnHeader}">
                           <Setter Property="HorizontalContentAlignment" Value="Left" />
@@ -653,7 +653,7 @@
                     <GridViewColumn
                       Width="80"
                       DisplayMemberBinding="{Binding Duration, StringFormat={}{0:mm\\:ss\\.ff}}">
-                      <GridViewColumnHeader Content="Duration" />
+                      <GridViewColumnHeader Name="DurationColumn" Content="Duration" />
                       <GridViewColumn.HeaderContainerStyle>
                         <Style TargetType="{x:Type GridViewColumnHeader}">
                           <Setter Property="HorizontalContentAlignment" Value="Left" />
@@ -664,7 +664,7 @@
                     <GridViewColumn
                       Width="70"
                       DisplayMemberBinding="{Binding Process.ProcessId}">
-                      <GridViewColumnHeader Content="Process ID" />
+                      <GridViewColumnHeader Name="ProcessIdColumn" Content="Process ID" />
                       <GridViewColumn.HeaderContainerStyle>
                         <Style TargetType="{x:Type GridViewColumnHeader}">
                           <Setter Property="HorizontalContentAlignment" Value="Left" />
@@ -675,7 +675,7 @@
                     <GridViewColumn
                       Width="150"
                       DisplayMemberBinding="{Binding Process.CommandLine}">
-                      <GridViewColumnHeader Content="Command line" />
+                      <GridViewColumnHeader Name="ProcessCommandLineColumn" Content="Command line" />
                       <GridViewColumn.HeaderContainerStyle>
                         <Style TargetType="{x:Type GridViewColumnHeader}">
                           <Setter Property="HorizontalContentAlignment" Value="Left" />

--- a/src/ProfileExplorerUI/Windows/ProfileLoadWindow.xaml.cs
+++ b/src/ProfileExplorerUI/Windows/ProfileLoadWindow.xaml.cs
@@ -24,6 +24,14 @@ using ProfileExplorer.Core.Profile.ETW;
 
 namespace ProfileExplorer.UI;
 
+public enum ProcessSortField {
+  ProcessName,
+  Weight,
+  Duration,
+  ProcessId,
+  CommandLine
+}
+
 public partial class ProfileLoadWindow : Window, INotifyPropertyChanged {
   private CancelableTaskInstance loadTask_;
   private bool isLoadingProfile_;
@@ -42,6 +50,7 @@ public partial class ProfileLoadWindow : Window, INotifyPropertyChanged {
   private ICollectionView perfCountersFilter_;
   private ICollectionView metricsFilter_;
   private ICollectionView processFilter_;
+  private GridViewColumnValueSorter<ProcessSortField> processListSorter_;
   private string profileFilePath_;
   private string binaryFilePath_;
   private bool showOnlyManagedProcesses_;
@@ -55,6 +64,13 @@ public partial class ProfileLoadWindow : Window, INotifyPropertyChanged {
     InitializeComponent();
     DataContext = this;
     Session = session;
+    
+    // Initialize the process list column sorter
+    processListSorter_ = new GridViewColumnValueSorter<ProcessSortField>(
+      ProcessList, 
+      MapColumnNameToSortField, 
+      CompareProcessSummaryValues);
+    
     loadTask_ = new CancelableTaskInstance();
     IsRecordMode = recordMode;
     loadedSession_ = loadedSession;
@@ -694,10 +710,12 @@ public partial class ProfileLoadWindow : Window, INotifyPropertyChanged {
   }
 
   private void DisplayProcessList(List<ProcessSummary> list, List<ProcessSummary> selectedProcSummary = null) {
-    list.Sort((a, b) => b.Weight.CompareTo(a.Weight));
     ProcessList.ItemsSource = null;
     ProcessList.ItemsSource = new ListCollectionView(list);
     ShowProcessList = true;
+    
+    // Set default sort by weight (highest first) to maintain current behavior
+    processListSorter_.SortByField(ProcessSortField.Weight, ListSortDirection.Descending);
 
     if (selectedProcSummary != null) {
       // Keep selected process after updating list.
@@ -1029,5 +1047,36 @@ public partial class ProfileLoadWindow : Window, INotifyPropertyChanged {
     if (e.Key == Key.Enter) {
       await LoadProfileTraceFileAndCloseWindow(symbolSettings_);
     }
+  }
+
+  // To be wrapped as a ColumnFieldMappingDelegate for use by GridViewColumnValueSorter instantiation
+  private ProcessSortField MapColumnNameToSortField(string columnName) {
+    return columnName switch {
+      "ProcessNameColumn" => ProcessSortField.ProcessName,
+      "WeightPercentageColumn" => ProcessSortField.Weight,
+      "DurationColumn" => ProcessSortField.Duration,
+      "ProcessIdColumn" => ProcessSortField.ProcessId,
+      "ProcessCommandLineColumn" => ProcessSortField.CommandLine,
+      _ => ProcessSortField.ProcessName
+    };
+  }
+
+  // To be wrapped as a ValueCompareDelegate for use by GridViewColumnValueSorter instantiation
+  private int CompareProcessSummaryValues(object x, object y, ProcessSortField field,
+                                          ListSortDirection direction, object tag) {
+    if (x is not ProcessSummary processX || y is not ProcessSummary processY) {
+      return 0;
+    }
+
+    int result = field switch {
+      ProcessSortField.ProcessName => string.Compare(processX.Process.Name, processY.Process.Name, StringComparison.OrdinalIgnoreCase),
+      ProcessSortField.Weight => processX.Weight.CompareTo(processY.Weight),
+      ProcessSortField.Duration => processX.Duration.CompareTo(processY.Duration),
+      ProcessSortField.ProcessId => processX.Process.ProcessId.CompareTo(processY.Process.ProcessId),
+      ProcessSortField.CommandLine => string.Compare(processX.Process.CommandLine ?? "", processY.Process.CommandLine ?? "", StringComparison.OrdinalIgnoreCase),
+      _ => 0
+    };
+
+    return direction == ListSortDirection.Ascending ? result : -result;
   }
 }


### PR DESCRIPTION
Users can now click any column header (Process, Weight, Duration, Process ID, Command Line) to sort the process selection table (in the load profile trace window) in ascending/descending order.

Using existing GridViewColumnValueSorter class to enable sorting by Process, Weight, Duration, Process ID, and Command Line. Maintains default Weight descending sort pattern while allowing user-controlled column header sorting. Replacing functionality that relied on a hardcoded sort by Weight while presenting clickable headers that implied variable sorting capability.