### PR TITLE
fix crash when reopening timeline view

### DIFF
--- a/src/ProfileExplorerUI/MainWindowPanels.cs
+++ b/src/ProfileExplorerUI/MainWindowPanels.cs
@@ -176,6 +176,7 @@ public partial class MainWindow : Window, IUISession {
     RegisterPanel(CallTreePanel, CallTreePanelHost);
     RegisterPanel(CallerCalleePanel, CallerCalleePanelHost);
     RegisterPanel(FlameGraphPanel, FlameGraphPanelHost);
+    RegisterPanel(TimelinePanel, TimelinePanelHost);
     RegisterPanel(HelpPanel, HelpPanelHost);
     RenameAllPanels();
 

--- a/src/ProfileExplorerUI/Panels/HelpPanel.xaml.cs
+++ b/src/ProfileExplorerUI/Panels/HelpPanel.xaml.cs
@@ -128,10 +128,6 @@ public partial class HelpPanel : ToolPanelControl {
   }
 
   public static async Task DisplayPanelHelp(ToolPanelKind kind, IUISession session) {
-    if (session == null) {
-      return;
-    }
-    
     if (await session.ShowPanel(ToolPanelKind.Help) is HelpPanel panel) {
       await panel.LoadPanelHelp(kind);
     }
@@ -139,9 +135,7 @@ public partial class HelpPanel : ToolPanelControl {
 
   private async Task NavigateToTopic(HelpTopic topic) {
     if (topic != null && !string.IsNullOrEmpty(topic.URL)) {
-      if (TopicTextBox != null) {
-        TopicTextBox.Text = topic.Title;
-      }
+      TopicTextBox.Text = topic.Title;
       currentTopic_ = topic;
       await NavigateToURL(App.GetHelpFilePath(topic.URL));
     }


### PR DESCRIPTION
Fixes #29

When a panel is closed, it gets unregistered and its `Session` property is set to null. When reopening via the ribbon menu, `ShowPanel()` calls `RegisterDefaultToolPanels()` to restore the `Session` property for all panels. However, `TimelinePanel` was not included in this list, causing its `Session` to remain null after reopening, which led to a `NullReferenceException` when clicking the Help button. Other profiling panels like `CallTreePanel` and `FlameGraphPanel` were properly included in `RegisterDefaultToolPanels()`, so they didn't exhibit this issue. `TimelinePanel` was only registered in the `RestoreDockLayout` deserialization callback, which runs at startup but not when manually reopening closed panels.