### PR TITLE
Better diagnostics on lazy binary loading and negative cache safeguards

### DIFF
--- a/scripts/Analyze-DiagnosticLog.ps1
+++ b/scripts/Analyze-DiagnosticLog.ps1
@@ -597,11 +597,13 @@ foreach ($line in $log) {
     }
     if ($lazyLoadStart -and ($line -match '\[LazyBinaryLoad\] Successfully loaded|\[LazyBinaryLoad\] Could not find|\[LazyBinaryLoad\] Found binary')) {
         $lazyLoadEnd = Get-TimestampFromLine $line
+        $lazyLoadSuccess = $line -match '\[LazyBinaryLoad\] (Successfully loaded|Found binary)'
         if ($lazyLoadEnd) {
             $lazyLoadMs = ($lazyLoadEnd - $lazyLoadStart).TotalMilliseconds
             [void]$lazyLoadOps.Add([PSCustomObject]@{
                 Module = $lazyLoadModule
                 DurationMs = $lazyLoadMs
+                Success = $lazyLoadSuccess
                 StartLine = $lazyLoadStartLine
                 EndLine = $lineNum
                 StartTime = $lazyLoadStart.ToString("HH:mm:ss.fff")
@@ -649,7 +651,10 @@ Write-Host "Total timestamped lines: $totalTimestamped"
 Write-Host "Initial load gaps > 500ms: $($gaps.Count)" -ForegroundColor $(if ($gaps.Count -gt 0) { "Yellow" } else { "Green" })
 if ($lazyLoadOps.Count -gt 0) {
     $lazyLoadTotal = ($lazyLoadOps | Measure-Object -Property DurationMs -Sum).Sum / 1000
-    Write-Host "Lazy load operations: $($lazyLoadOps.Count) binaries ($([math]::Round($lazyLoadTotal, 1))s total)" -ForegroundColor Cyan
+    $lazyLoadFailCount = @($lazyLoadOps | Where-Object { -not $_.Success }).Count
+    $lazyLoadColor = if ($lazyLoadFailCount -gt 0) { "Red" } else { "Cyan" }
+    $lazyLoadSuffix = if ($lazyLoadFailCount -gt 0) { ", $lazyLoadFailCount FAILED" } else { "" }
+    Write-Host "Lazy load operations: $($lazyLoadOps.Count) binaries ($([math]::Round($lazyLoadTotal, 1))s total$lazyLoadSuffix)" -ForegroundColor $lazyLoadColor
 }
 Write-Host ""
 
@@ -726,14 +731,24 @@ if ($lazyLoadOps.Count -gt 0) {
     Write-Host "Time spent downloading binaries when user views assembly/graph." -ForegroundColor Gray
     Write-Host ""
 
+    $lazyLoadSucceeded = @($lazyLoadOps | Where-Object { $_.Success })
+    $lazyLoadFailed = @($lazyLoadOps | Where-Object { -not $_.Success })
+
     foreach ($op in $lazyLoadOps | Sort-Object DurationMs -Descending | Select-Object -First 10) {
         $secs = [math]::Round($op.DurationMs / 1000, 2)
-        $color = if ($op.DurationMs -gt 5000) { "Red" } elseif ($op.DurationMs -gt 2000) { "Yellow" } else { "White" }
-        Write-Host ("  {0,6}ms ({1,5}s) - {2}" -f [int]$op.DurationMs, $secs, $op.Module) -ForegroundColor $color
+        $status = if ($op.Success) { "OK" } else { "FAILED" }
+        $color = if (-not $op.Success) { "Red" } elseif ($op.DurationMs -gt 5000) { "Yellow" } elseif ($op.DurationMs -gt 2000) { "Yellow" } else { "Green" }
+        Write-Host ("  {0,6}ms ({1,5}s) - {2} [{3}]" -f [int]$op.DurationMs, $secs, $op.Module, $status) -ForegroundColor $color
     }
 
     $lazyLoadTotal = ($lazyLoadOps | Measure-Object -Property DurationMs -Sum).Sum / 1000
     Write-Host ""
+    if ($lazyLoadFailed.Count -gt 0) {
+        Write-Host "  Succeeded: $($lazyLoadSucceeded.Count), Failed: $($lazyLoadFailed.Count)" -ForegroundColor Red
+        Write-Host "  Failed modules: $($lazyLoadFailed.Module -join ', ')" -ForegroundColor Red
+    } else {
+        Write-Host "  All $($lazyLoadSucceeded.Count) lazy loads succeeded" -ForegroundColor Green
+    }
     Write-Host "  Total lazy load time: $([math]::Round($lazyLoadTotal, 1))s" -ForegroundColor Cyan
 }
 

--- a/src/ProfileExplorerCore/Binary/PDBDebugInfoProvider.cs
+++ b/src/ProfileExplorerCore/Binary/PDBDebugInfoProvider.cs
@@ -479,7 +479,7 @@ public sealed class PDBDebugInfoProvider : IDebugInfoProvider {
 
     // Check for auth failure on primary server, but ONLY if primary has never been verified working.
     // Once we've successfully downloaded from symweb, we NEVER fall back to msdl (would get worse symbols).
-    if (!settings.PrimaryServerVerified && !settings.PrimaryServerAuthFailed && DetectPrimaryServerAuthFailure(searchLog)) {
+    if (!settings.PrimaryServerVerified && !settings.PrimaryServerAuthFailed && SymbolFileSourceSettings.DetectPrimaryServerAuthFailure(searchLog)) {
       settings.PrimaryServerAuthFailed = true;
       DiagnosticLogger.LogWarning($"[SymbolSearch] Primary server (symweb) auth FAILED - switching to secondary (public) server for remaining downloads");
     }
@@ -505,7 +505,7 @@ public sealed class PDBDebugInfoProvider : IDebugInfoProvider {
       // If download succeeded and log shows symweb was used, mark primary as verified
       if (!settings.PrimaryServerVerified &&
           searchLog.Contains("symweb", StringComparison.OrdinalIgnoreCase) &&
-          !DetectPrimaryServerAuthFailure(searchLog)) {
+          !SymbolFileSourceSettings.DetectPrimaryServerAuthFailure(searchLog)) {
         settings.PrimaryServerVerified = true;
         DiagnosticLogger.LogInfo($"[SymbolSearch] Primary server (symweb) auth VERIFIED - will continue using primary server");
       }
@@ -518,7 +518,7 @@ public sealed class PDBDebugInfoProvider : IDebugInfoProvider {
       settings.SessionSymbolFailureCount++;
 
       // Classify the failure to determine if it should be cached
-      var reason = ClassifySymbolSearchFailure(searchLog, settings);
+      var reason = settings.ClassifySearchFailure(searchLog);
       DiagnosticLogger.LogInfo($"[SymbolSearch] Failure classified as: {reason}");
 
       // Record failed lookup with reason - RejectSymbolFile has safeguards to prevent caching transient failures
@@ -528,44 +528,6 @@ public sealed class PDBDebugInfoProvider : IDebugInfoProvider {
     resolvedSymbolsCache_.TryAdd(symbolFile, searchResult);
     DiagnosticLogger.LogInfo($"[SymbolSearch] Cached search result for {symbolFile.FileName}: {(searchResult.Found ? "Success" : "Failure")}");
     return searchResult;
-  }
-
-  /// <summary>
-  /// Classifies a symbol search failure based on the search log to determine if it should be cached.
-  /// Returns a SymbolFileRejectionReason indicating whether the failure is permanent (cacheable)
-  /// or transient (should not be cached).
-  /// </summary>
-  private static SymbolFileRejectionReason ClassifySymbolSearchFailure(
-    string searchLog, SymbolFileSourceSettings settings) {
-
-    // Check for auth failures (401/403)
-    if (DetectPrimaryServerAuthFailure(searchLog)) {
-      return SymbolFileRejectionReason.AuthenticationFailure;
-    }
-
-    // Check for server errors (5xx)
-    if (!string.IsNullOrEmpty(searchLog) &&
-        (searchLog.Contains("500") || searchLog.Contains("503") ||
-         searchLog.Contains("Internal Server Error", StringComparison.OrdinalIgnoreCase))) {
-      return SymbolFileRejectionReason.ServerError;
-    }
-
-    // Check for timeout patterns
-    if (!string.IsNullOrEmpty(searchLog) &&
-        (searchLog.Contains("timeout", StringComparison.OrdinalIgnoreCase) ||
-         searchLog.Contains("timed out", StringComparison.OrdinalIgnoreCase))) {
-      return SymbolFileRejectionReason.NetworkTimeout;
-    }
-
-    // If file not found in search log (404 or no result)
-    if (string.IsNullOrEmpty(searchLog) ||
-        searchLog.Contains("404") ||
-        searchLog.Contains("not found", StringComparison.OrdinalIgnoreCase)) {
-      return SymbolFileRejectionReason.PermanentNotFound;
-    }
-
-    // Default: unknown (treat conservatively - don't cache if unsure)
-    return SymbolFileRejectionReason.Unknown;
   }
 
   // Track if we've logged detailed symbol path info (only log once per session unless auth state changes)
@@ -626,48 +588,6 @@ public sealed class PDBDebugInfoProvider : IDebugInfoProvider {
     }
 
     return symbolPath;
-  }
-
-  /// <summary>
-  /// Checks if the search log indicates an auth failure (401/403) on the primary server.
-  /// Uses specific patterns to avoid false positives from GUIDs/paths that contain "401" or "403".
-  /// </summary>
-  private static bool DetectPrimaryServerAuthFailure(string searchLog) {
-    if (string.IsNullOrEmpty(searchLog)) {
-      return false;
-    }
-
-    // Must involve symweb to be a primary server auth failure
-    if (!searchLog.Contains("symweb", StringComparison.OrdinalIgnoreCase)) {
-      return false;
-    }
-
-    // Look for specific auth failure patterns - not just "401"/"403" which can match GUIDs/paths
-    // TraceEvent typically outputs HTTP errors with context like "Response: 401" or "401 Unauthorized"
-    // Use regex with word boundaries to avoid matching 401/403 within hex GUIDs
-    var authFailurePatterns = new[] {
-      @"\b401\b",           // 401 at word boundary (not in hex GUIDs like A3401B)
-      @"\b403\b",           // 403 at word boundary
-      "Unauthorized",       // HTTP 401 description
-      "Forbidden"           // HTTP 403 description
-    };
-
-    foreach (var pattern in authFailurePatterns) {
-      if (pattern.StartsWith(@"\b")) {
-        // Regex pattern - check for word boundaries
-        if (System.Text.RegularExpressions.Regex.IsMatch(searchLog, pattern)) {
-          return true;
-        }
-      }
-      else {
-        // Simple string search for descriptive terms
-        if (searchLog.Contains(pattern, StringComparison.OrdinalIgnoreCase)) {
-          return true;
-        }
-      }
-    }
-
-    return false;
   }
 
   public static async Task<DebugFileSearchResult>

--- a/src/ProfileExplorerCore/Binary/PEBinaryInfoProvider.cs
+++ b/src/ProfileExplorerCore/Binary/PEBinaryInfoProvider.cs
@@ -264,6 +264,14 @@ public sealed class PEBinaryInfoProvider : IBinaryInfoProvider, IDisposable {
       return searchResult;
     }
 
+    // Resolve NT kernel paths like \SystemRoot\system32\ntoskrnl.exe
+    // to actual file system paths like C:\Windows\system32\ntoskrnl.exe.
+    string resolvedPath = ResolveNtKernelPath(binaryFile.ImagePath);
+    if (resolvedPath != binaryFile.ImagePath) {
+      DiagnosticLogger.LogInfo($"[BinarySearch] Resolved NT path for {binaryFile.ImageName}: {binaryFile.ImagePath} -> {resolvedPath}");
+      binaryFile.ImagePath = resolvedPath;
+    }
+
     // Quick check if trace was recorded on local machine.
     string result = FindExactLocalBinaryFile(binaryFile);
 
@@ -279,8 +287,10 @@ public sealed class PEBinaryInfoProvider : IBinaryInfoProvider, IDisposable {
 
     try {
       // Try to use symbol server to download binary.
+      // Add local binary path directly instead of using WithSymbolPaths (which clones
+      // settings again and resets runtime state like timeout overrides).
       if (File.Exists(binaryFile.ImagePath)) {
-        settings = settings.WithSymbolPaths(binaryFile.ImagePath);
+        settings.InsertSymbolPath(binaryFile.ImagePath);
       }
 
       string userSearchPath = PDBDebugInfoProvider.ConstructSymbolSearchPath(settings);
@@ -341,12 +351,27 @@ public sealed class PEBinaryInfoProvider : IBinaryInfoProvider, IDisposable {
       DiagnosticLogger.LogWarning($"[BinarySearch] Failed to find binary for {binaryFile.ImageName} ({searchDuration.TotalMilliseconds:F0}ms)");
       searchResult = BinaryFileSearchResult.Failure(binaryFile, searchLog);
 
-      // Record failed lookup to avoid retrying in future sessions.
-      settings.RejectBinaryFile(binaryFile);
+      // Record failed lookup to avoid retrying in future sessions,
+      // but skip transient failures (timeout, auth, server errors).
+      var reason = settings.ClassifySearchFailure(searchLog);
+      settings.RejectBinaryFile(binaryFile, reason, searchLog);
     }
 
     resolvedBinariesCache_.TryAdd(binaryFile, searchResult);
     return searchResult;
+  }
+
+  private static string ResolveNtKernelPath(string path) {
+    if (string.IsNullOrEmpty(path)) {
+      return path;
+    }
+
+    if (path.StartsWith(@"\SystemRoot", StringComparison.OrdinalIgnoreCase)) {
+      string systemRoot = Environment.GetEnvironmentVariable("SystemRoot") ?? @"C:\Windows";
+      return systemRoot + path.Substring(@"\SystemRoot".Length);
+    }
+
+    return path;
   }
 
   private static string FindExactLocalBinaryFile(BinaryFileDescriptor binaryFile) {

--- a/src/ProfileExplorerCore/Profile/Data/ProfileModuleBuilder.cs
+++ b/src/ProfileExplorerCore/Profile/Data/ProfileModuleBuilder.cs
@@ -201,9 +201,24 @@ public sealed class ProfileModuleBuilder : IDisposable {
       string imageName = binaryInfo_.ImageName;
       DiagnosticLogger.LogInfo($"[LazyBinaryLoad] Loading binary on-demand for {imageName}");
 
-      var binFile = await FindBinaryFilePath(symbolSettings_).ConfigureAwait(false);
+      // Clone settings with fresh timeout state for on-demand download.
+      // The shared symbolSettings_ may have degraded/reduced timeouts from the PDB pre-download phase,
+      // but the user is actively waiting for this binary so use generous timeout (BellwetherTimeoutSeconds = 60s).
+      var downloadSettings = symbolSettings_.Clone();
+      downloadSettings.HadFirstSuccessfulNetworkRequest = true;
+      DiagnosticLogger.LogInfo($"[LazyBinaryLoad] Cloned settings for {imageName}: " +
+        $"EffectiveTimeout={downloadSettings.EffectiveTimeoutSeconds}s, " +
+        $"BellwetherTimeout={downloadSettings.BellwetherTimeoutSeconds}s, " +
+        $"HadFirstSuccess={downloadSettings.HadFirstSuccessfulNetworkRequest}, " +
+        $"Degraded={downloadSettings.SymbolServerDegraded}, " +
+        $"HadTimeout={downloadSettings.HadFirstTimeout}");
+
+      var binFile = await FindBinaryFilePath(downloadSettings).ConfigureAwait(false);
       if (binFile == null || !binFile.Found) {
         DiagnosticLogger.LogWarning($"[LazyBinaryLoad] Could not find binary for {imageName}");
+
+        // Update state from LazyLoadPending to NotFound so the UI shows the failure.
+        report_.AddModuleInfo(binaryInfo_, binFile, ModuleLoadState.NotFound);
         return false;
       }
 

--- a/src/ProfileExplorerCore/Settings/SymbolFileSourceSettings.cs
+++ b/src/ProfileExplorerCore/Settings/SymbolFileSourceSettings.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using ProfileExplorer.Core.Binary;
 using ProfileExplorer.Core.Session;
 using ProfileExplorer.Core.Utilities;
@@ -246,6 +247,72 @@ public class SymbolFileSourceSettings : SettingsBase {
   }
 
   /// <summary>
+  /// Classifies a search failure based on the search log to determine if it should be cached.
+  /// Used by both PDB and binary rejection to distinguish transient failures (timeout, auth, server errors)
+  /// from permanent failures (404 not found).
+  /// </summary>
+  public SymbolFileRejectionReason ClassifySearchFailure(string searchLog) {
+    if (DetectPrimaryServerAuthFailure(searchLog)) {
+      return SymbolFileRejectionReason.AuthenticationFailure;
+    }
+
+    if (!string.IsNullOrEmpty(searchLog) &&
+        (searchLog.Contains("500") || searchLog.Contains("503") ||
+         searchLog.Contains("Internal Server Error", StringComparison.OrdinalIgnoreCase))) {
+      return SymbolFileRejectionReason.ServerError;
+    }
+
+    if (!string.IsNullOrEmpty(searchLog) &&
+        (searchLog.Contains("timeout", StringComparison.OrdinalIgnoreCase) ||
+         searchLog.Contains("timed out", StringComparison.OrdinalIgnoreCase))) {
+      return SymbolFileRejectionReason.NetworkTimeout;
+    }
+
+    if (string.IsNullOrEmpty(searchLog) ||
+        searchLog.Contains("404") ||
+        searchLog.Contains("not found", StringComparison.OrdinalIgnoreCase)) {
+      return SymbolFileRejectionReason.PermanentNotFound;
+    }
+
+    return SymbolFileRejectionReason.Unknown;
+  }
+
+  /// <summary>
+  /// Detects if the search log indicates a primary symbol server (symweb) authentication failure.
+  /// </summary>
+  public static bool DetectPrimaryServerAuthFailure(string searchLog) {
+    if (string.IsNullOrEmpty(searchLog)) {
+      return false;
+    }
+
+    if (!searchLog.Contains("symweb", StringComparison.OrdinalIgnoreCase)) {
+      return false;
+    }
+
+    var authFailurePatterns = new[] {
+      @"\b401\b",           // 401 at word boundary (not in hex GUIDs like A3401B)
+      @"\b403\b",           // 403 at word boundary
+      "Unauthorized",       // HTTP 401 description
+      "Forbidden"           // HTTP 403 description
+    };
+
+    foreach (var pattern in authFailurePatterns) {
+      if (pattern.StartsWith(@"\b")) {
+        if (Regex.IsMatch(searchLog, pattern)) {
+          return true;
+        }
+      }
+      else {
+        if (searchLog.Contains(pattern, StringComparison.OrdinalIgnoreCase)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  /// <summary>
   /// Checks if a symbol file exists in the local symbol cache directories.
   /// Searches all paths from _NT_SYMBOL_PATH including structured (foo.pdb/GUID/foo.pdb) and flat directories.
   /// </summary>
@@ -354,14 +421,34 @@ public class SymbolFileSourceSettings : SettingsBase {
     return false;
   }
 
-  public void RejectBinaryFile(BinaryFileDescriptor file) {
-    if (RejectPreviouslyFailedFiles) {
-      RejectedBinaryFiles.Add(file);
-      // Update cache time on first rejection
-      if (RejectedFilesCacheTime == default) {
-        RejectedFilesCacheTime = DateTime.UtcNow;
-      }
+  public bool RejectBinaryFile(BinaryFileDescriptor file,
+                               SymbolFileRejectionReason reason = SymbolFileRejectionReason.Unknown,
+                               string searchLog = null) {
+    if (!RejectPreviouslyFailedFiles) return false;
+
+    // Same safeguards as RejectSymbolFile: don't cache transient failures.
+    if (IsTransientFailure(reason)) {
+      DiagnosticLogger.LogInfo($"[NegativeCache] Skipping transient binary failure: {file.ImageName} - {reason}");
+      return false;
     }
+
+    if (PrimaryServerAuthFailed) {
+      DiagnosticLogger.LogWarning($"[NegativeCache] Auth failure detected - skipping binary rejection for {file.ImageName}");
+      return false;
+    }
+
+    if (ShouldSkipNegativeCachingDueToSuspiciousFailureRate()) {
+      DiagnosticLogger.LogWarning($"[NegativeCache] Suspicious failure rate - skipping binary rejection");
+      return false;
+    }
+
+    RejectedBinaryFiles.Add(file);
+    if (RejectedFilesCacheTime == default) {
+      RejectedFilesCacheTime = DateTime.UtcNow;
+    }
+
+    DiagnosticLogger.LogInfo($"[NegativeCache] Added binary: {file.ImageName} - Reason: {reason}");
+    return true;
   }
 
   /// <summary>

--- a/src/ProfileExplorerUI/Mcp/McpActionExecutor.cs
+++ b/src/ProfileExplorerUI/Mcp/McpActionExecutor.cs
@@ -1964,8 +1964,7 @@ public class McpActionExecutor : IMcpActionExecutor
                             Name = module.ModuleName,
                             ExclusivePercentage = weightPercentage * 100.0, // convert 0.abcd decimal to ab.cd percent
                             ExclusiveWeight = pair.Value,
-                            // Use IsBinaryAvailableOrPending to avoid reporting missing when lazy loading is available
-                            BinaryFileMissing = moduleStatus != null ? !moduleStatus.IsBinaryAvailableOrPending : false,
+                            Status = moduleStatus,
                             DebugFileMissing = moduleStatus != null ? !moduleStatus.HasDebugInfoLoaded : false,
                         };
 

--- a/src/ProfileExplorerUI/OptionsPanels/SymbolOptionsPanel.xaml.cs
+++ b/src/ProfileExplorerUI/OptionsPanels/SymbolOptionsPanel.xaml.cs
@@ -226,6 +226,11 @@ public partial class SymbolOptionsPanel : OptionsPanelBase, INotifyPropertyChang
     var symbolList = symbolSettings_.RejectedSymbolFiles.ToList();
     symbolList.Sort((a, b) => string.Compare(a.FileName, b.FileName, StringComparison.OrdinalIgnoreCase));
     RejectedSymbolsList.ItemsSource = symbolList;
+
+    // Force refresh of count bindings since HashSet doesn't notify on changes.
+    var dc = DataContext;
+    DataContext = null;
+    DataContext = dc;
   }
 
   public void OnPropertyChange(string propertyname) {

--- a/src/ProfileExplorerUI/Panels/SectionPanel.xaml.cs
+++ b/src/ProfileExplorerUI/Panels/SectionPanel.xaml.cs
@@ -404,7 +404,7 @@ public class ModuleEx {
   public Brush BackColor { get; set; }
   public double ExclusivePercentage { get; set; }
   public TimeSpan ExclusiveWeight { get; set; }
-  public bool BinaryFileMissing { get; set; }
+  public bool BinaryFileMissing => Status != null ? !Status.IsBinaryAvailableOrPending : false;
   public bool DebugFileMissing { get; set; }
   public ProfileDataReport.ModuleStatus Status { get; set; }
 }
@@ -1694,8 +1694,6 @@ public partial class SectionPanel : ToolPanelControl, INotifyPropertyChanged {
 
       if (moduleStatus != null) {
         moduleInfo.Status = moduleStatus;
-        // Use IsBinaryAvailableOrPending to avoid showing error icon when lazy loading is available
-        moduleInfo.BinaryFileMissing = !moduleStatus.IsBinaryAvailableOrPending;
         moduleInfo.DebugFileMissing = !moduleStatus.HasDebugInfoLoaded;
 
         // Log the module status for debugging


### PR DESCRIPTION
  - Clone symbol settings in EnsureBinaryLoaded() to get fresh timeout state instead of degraded timeouts from PDB pre-download phase
  - Fix WithSymbolPaths() double-clone in LocateBinaryFile() that was silently wiping runtime timeout overrides on the cloned settings
  - Add ResolveNtKernelPath() for \SystemRoot\ paths in ETL traces
  - Unify search failure classification: move ClassifySearchFailure and DetectPrimaryServerAuthFailure to SymbolFileSourceSettings so both PDB and binary rejection use the same transient failure safeguards (timeout, auth, server errors skip negative cache)
  - Update module state from LazyLoadPending to NotFound on lazy load failure so UI shows the error icon and binary search log
  - Make ModuleEx.BinaryFileMissing a computed property from live Status
  - Fix excluded symbols/binaries count not updating after Clear in settings UI (HashSet doesn't notify WPF bindings)
  - Update Analyze-DiagnosticLog.ps1 to track and display lazy load success/failure status