### PR TITLE
 Improves how process weights are calculated and displayed in the profile loading UI. Default filter out Idle

### DIFF
--- a/src/ProfileExplorerCore/Profile/Data/IProfileDataProvider.cs
+++ b/src/ProfileExplorerCore/Profile/Data/IProfileDataProvider.cs
@@ -63,10 +63,10 @@ public class ProcessSummary {
   public TimeSpan Weight { get; set; }
   [ProtoMember(3)]
   public double WeightPercentage { get; set; }
-  [ProtoMember(5)]
-  public double WeightPercentageExcludingIdle { get; set; }
   [ProtoMember(4)]
   public TimeSpan Duration { get; set; }
+  [ProtoMember(5)]
+  public double WeightPercentageExcludingIdle { get; set; }
 
   public override string ToString() {
     return $"{Process.Name} ({Weight})";

--- a/src/ProfileExplorerCore/Profile/Data/IProfileDataProvider.cs
+++ b/src/ProfileExplorerCore/Profile/Data/IProfileDataProvider.cs
@@ -63,6 +63,8 @@ public class ProcessSummary {
   public TimeSpan Weight { get; set; }
   [ProtoMember(3)]
   public double WeightPercentage { get; set; }
+  [ProtoMember(5)]
+  public double WeightPercentageExcludingIdle { get; set; }
   [ProtoMember(4)]
   public TimeSpan Duration { get; set; }
 

--- a/src/ProfileExplorerCore/Profile/Data/ProcessSummaryBuilder.cs
+++ b/src/ProfileExplorerCore/Profile/Data/ProcessSummaryBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 using System;
 using System.Collections.Generic;
@@ -9,8 +9,8 @@ namespace ProfileExplorer.Core.Profile.Data;
 
 public class ProcessSummaryBuilder {
   private RawProfileData profile_;
-  private Dictionary<ProfileProcess, TimeSpan> processSamples_ = new();
-  private Dictionary<ProfileProcess, (TimeSpan First, TimeSpan Last)> procDuration_ = new();
+  private Dictionary<int, TimeSpan> processSamples_ = new();
+  private Dictionary<int, (TimeSpan First, TimeSpan Last)> procDuration_ = new();
   private TimeSpan totalWeight_;
 
   public ProcessSummaryBuilder(RawProfileData profile) {
@@ -19,12 +19,13 @@ public class ProcessSummaryBuilder {
 
   public void AddSample(ProfileSample sample) {
     var context = sample.GetContext(profile_);
-    var process = profile_.GetOrCreateProcess(context.ProcessId);
-    processSamples_.AccumulateValue(process, sample.Weight);
+    int processId = context.ProcessId;
+    profile_.GetOrCreateProcess(processId); // Ensure process object exists.
+    processSamples_.AccumulateValue(processId, sample.Weight);
     totalWeight_ += sample.Weight;
 
     // Modify in-place.
-    ref var durationRef = ref CollectionsMarshal.GetValueRefOrAddDefault(procDuration_, process, out bool found);
+    ref var durationRef = ref CollectionsMarshal.GetValueRefOrAddDefault(procDuration_, processId, out bool found);
 
     if (!found) {
       durationRef.First = sample.Time;
@@ -34,12 +35,12 @@ public class ProcessSummaryBuilder {
   }
 
   public void AddSample(TimeSpan sampleWeight, TimeSpan sampleTime, int processId) {
-    var process = profile_.GetOrCreateProcess(processId);
-    processSamples_.AccumulateValue(process, sampleWeight);
+    profile_.GetOrCreateProcess(processId); // Ensure process object exists.
+    processSamples_.AccumulateValue(processId, sampleWeight);
     totalWeight_ += sampleWeight;
 
     // Modify in-place.
-    ref var durationRef = ref CollectionsMarshal.GetValueRefOrAddDefault(procDuration_, process, out bool found);
+    ref var durationRef = ref CollectionsMarshal.GetValueRefOrAddDefault(procDuration_, processId, out bool found);
 
     if (!found) {
       durationRef.First = sampleTime;
@@ -51,9 +52,22 @@ public class ProcessSummaryBuilder {
   public List<ProcessSummary> MakeSummaries() {
     var list = new List<ProcessSummary>(procDuration_.Count);
 
+    // Calculate non-idle total weight for the excluding-idle percentage.
+    long nonIdleWeightTicks = totalWeight_.Ticks;
+
+    if (processSamples_.TryGetValue(ETW.ETWEventProcessor.KernelProcessId, out var idleWeight)) {
+      nonIdleWeightTicks -= idleWeight.Ticks;
+    }
+
     foreach (var pair in processSamples_) {
-      var item = new ProcessSummary(pair.Key, pair.Value) {
-        WeightPercentage = 100 * (double)pair.Value.Ticks / totalWeight_.Ticks
+      var process = profile_.GetOrCreateProcess(pair.Key);
+      var item = new ProcessSummary(process, pair.Value) {
+        WeightPercentage = totalWeight_.Ticks > 0
+          ? 100 * (double)pair.Value.Ticks / totalWeight_.Ticks
+          : 0,
+        WeightPercentageExcludingIdle = nonIdleWeightTicks > 0
+          ? 100 * (double)pair.Value.Ticks / nonIdleWeightTicks
+          : 0
       };
 
       list.Add(item);

--- a/src/ProfileExplorerCore/Profile/Data/ProcessSummaryBuilder.cs
+++ b/src/ProfileExplorerCore/Profile/Data/ProcessSummaryBuilder.cs
@@ -61,13 +61,27 @@ public class ProcessSummaryBuilder {
 
     foreach (var pair in processSamples_) {
       var process = profile_.GetOrCreateProcess(pair.Key);
+
+      double weightPercentage = totalWeight_.Ticks > 0
+        ? 100 * (double)pair.Value.Ticks / totalWeight_.Ticks
+        : 0;
+
+      double weightPercentageExcludingIdle;
+      if (nonIdleWeightTicks > 0) {
+        if (pair.Key == ETW.ETWEventProcessor.KernelProcessId) {
+          // For the idle/kernel process, the excluding-idle percentage is not meaningful.
+          // Set it equal to the overall weight percentage to avoid confusing values.
+          weightPercentageExcludingIdle = weightPercentage;
+        } else {
+          weightPercentageExcludingIdle = 100 * (double)pair.Value.Ticks / nonIdleWeightTicks;
+        }
+      } else {
+        weightPercentageExcludingIdle = 0;
+      }
+
       var item = new ProcessSummary(process, pair.Value) {
-        WeightPercentage = totalWeight_.Ticks > 0
-          ? 100 * (double)pair.Value.Ticks / totalWeight_.Ticks
-          : 0,
-        WeightPercentageExcludingIdle = nonIdleWeightTicks > 0
-          ? 100 * (double)pair.Value.Ticks / nonIdleWeightTicks
-          : 0
+        WeightPercentage = weightPercentage,
+        WeightPercentageExcludingIdle = weightPercentageExcludingIdle
       };
 
       list.Add(item);

--- a/src/ProfileExplorerUI/Mcp/McpActionExecutor.cs
+++ b/src/ProfileExplorerUI/Mcp/McpActionExecutor.cs
@@ -1346,9 +1346,9 @@ public class McpActionExecutor : IMcpActionExecutor
                 };
             }
 
-            // Exclude Idle (PID 0) and use non-idle percentages for meaningful results.
+            // Exclude Idle/kernel process and use non-idle percentages for meaningful results.
             var processes = processSummaries
-                .Where(p => p.Process.ProcessId != 0)
+                .Where(p => p.Process.ProcessId != ETWEventProcessor.KernelProcessId)
                 .Select(p => new ProcessInfo
             {
                 ProcessId = p.Process.ProcessId,

--- a/src/ProfileExplorerUI/Mcp/McpActionExecutor.cs
+++ b/src/ProfileExplorerUI/Mcp/McpActionExecutor.cs
@@ -1346,14 +1346,17 @@ public class McpActionExecutor : IMcpActionExecutor
                 };
             }
 
-            var processes = processSummaries.Select(p => new ProcessInfo
+            // Exclude Idle (PID 0) and use non-idle percentages for meaningful results.
+            var processes = processSummaries
+                .Where(p => p.Process.ProcessId != 0)
+                .Select(p => new ProcessInfo
             {
                 ProcessId = p.Process.ProcessId,
                 Name = p.Process.Name ?? string.Empty,
                 ImageFileName = p.Process.ImageFileName,
                 CommandLine = p.Process.CommandLine,
                 Weight = p.Weight,
-                WeightPercentage = p.WeightPercentage,
+                WeightPercentage = p.WeightPercentageExcludingIdle,
                 Duration = p.Duration
             }).ToArray();
 

--- a/src/ProfileExplorerUI/Mcp/McpActionExecutor.cs
+++ b/src/ProfileExplorerUI/Mcp/McpActionExecutor.cs
@@ -11,6 +11,8 @@ using System.Windows.Input;
 using System.Windows.Threading;
 using ProfileExplorer.Mcp;
 using ProfileExplorer.Core.Profile.Data;
+using ProfileExplorer.Core.Profile.ETW;
+using ProfileExplorer.Core.Utilities;
 using ProfileExplorer.Core.IR;
 
 namespace ProfileExplorer.UI.Mcp;
@@ -1325,20 +1327,36 @@ public class McpActionExecutor : IMcpActionExecutor
 
         try
         {
-            // Load the trace and prepare the process list (similar to OpenTraceAsync but standalone)
-            var loadResult = await LoadTraceAsync(profileFilePath);
-            if (!loadResult.Success)
+            // Call FindTraceProcesses directly instead of opening the UI window.
+            // This avoids a race condition where the UI's double TextChanged invocation
+            // could cause WaitForProcessListLoadedAsync to read an incomplete intermediate list.
+            using var cancelableTask = new CancelableTask();
+            var options = App.Settings.ProfileOptions;
+
+            // Progress callback must be non-null (ETWEventProcessor calls it unconditionally).
+            var processSummaries = await ETWProfileDataProvider.FindTraceProcesses(
+                profileFilePath, options, _ => { }, cancelableTask);
+
+            if (processSummaries == null || processSummaries.Count == 0)
             {
                 return new GetAvailableProcessesResult
                 {
                     Success = false,
-                    ErrorMessage = loadResult.Result?.ErrorMessage ?? "Failed to load trace file"
+                    ErrorMessage = "Failed to extract process list from trace file"
                 };
             }
 
-            // Extract process information from the loaded trace
-            var processes = await ExtractProcessInfoAsync(loadResult.ProfileLoadWindow);
-            
+            var processes = processSummaries.Select(p => new ProcessInfo
+            {
+                ProcessId = p.Process.ProcessId,
+                Name = p.Process.Name ?? string.Empty,
+                ImageFileName = p.Process.ImageFileName,
+                CommandLine = p.Process.CommandLine,
+                Weight = p.Weight,
+                WeightPercentage = p.WeightPercentage,
+                Duration = p.Duration
+            }).ToArray();
+
             // Apply weight filtering if specified
             if (minWeightPercentage.HasValue)
             {
@@ -1354,7 +1372,7 @@ public class McpActionExecutor : IMcpActionExecutor
                     .Where(p => p.WeightPercentage >= minWeightPercentage.Value)
                     .ToArray();
             }
-            
+
             // Apply top N filtering if specified
             if (topCount.HasValue)
             {
@@ -1372,12 +1390,6 @@ public class McpActionExecutor : IMcpActionExecutor
                     .ToArray();
                 }
             }
-            
-            // Close the profile load window since we're just extracting process info
-            await dispatcher.InvokeAsync(() =>
-            {
-                loadResult.ProfileLoadWindow?.Close();
-            });
 
             return new GetAvailableProcessesResult
             {
@@ -1469,46 +1481,6 @@ public class McpActionExecutor : IMcpActionExecutor
         }
         
         return sanitized;
-    }
-
-    /// <summary>
-    /// Extract process information from the ProfileLoadWindow
-    /// </summary>
-    private async Task<ProcessInfo[]> ExtractProcessInfoAsync(ProfileExplorer.UI.ProfileLoadWindow profileLoadWindow)
-    {
-        try
-        {
-            return await dispatcher.InvokeAsync(() =>
-            {
-                var processListControl = profileLoadWindow.FindName("ProcessList") as System.Windows.Controls.ListView;
-                if (processListControl?.ItemsSource != null)
-                {
-                    try
-                    {
-                        var processSummaries = processListControl.ItemsSource.Cast<ProcessSummary>().ToList();
-                        return processSummaries.Select(p => new ProcessInfo
-                        {
-                            ProcessId = p.Process.ProcessId,
-                            Name = p.Process.Name ?? string.Empty,
-                            ImageFileName = p.Process.ImageFileName,
-                            CommandLine = p.Process.CommandLine,
-                            Weight = p.Weight,
-                            WeightPercentage = p.WeightPercentage,
-                            Duration = p.Duration
-                        }).ToArray();
-                    }
-                    catch
-                    {
-                        return Array.Empty<ProcessInfo>();
-                    }
-                }
-                return Array.Empty<ProcessInfo>();
-            });
-        }
-        catch
-        {
-            return Array.Empty<ProcessInfo>();
-        }
     }
 
     public async Task<GetAvailableFunctionsResult> GetAvailableFunctionsAsync(FunctionFilter? filter = null)

--- a/src/ProfileExplorerUI/Windows/ProfileLoadWindow.xaml
+++ b/src/ProfileExplorerUI/Windows/ProfileLoadWindow.xaml
@@ -15,11 +15,9 @@
   Height="600"
   MinWidth="600"
   MinHeight="400"
-  MaxHeight="800"
   d:DesignHeight="1200"
   ResizeMode="CanResizeWithGrip"
   ShowInTaskbar="False"
-  SizeToContent="Height"
   WindowStartupLocation="CenterOwner"
   WindowStyle="ToolWindow"
   mc:Ignorable="d">
@@ -134,9 +132,6 @@
           </ListBox.ItemContainerStyle>
         </ListBox>
       </Grid>
-      <ScrollViewer
-        HorizontalScrollBarVisibility="Disabled"
-        VerticalScrollBarVisibility="Auto">
         <TabControl
           VerticalAlignment="Stretch"
           Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
@@ -145,9 +140,10 @@
           <TabItem
             Header="Session"
             Style="{StaticResource TabControlStyle}">
-            <StackPanel Orientation="Vertical">
+            <DockPanel>
               <StackPanel
                 x:Name="ProfileCapturePanel"
+                DockPanel.Dock="Top"
                 Visibility="{Binding IsRecordMode, Converter={StaticResource BoolToVisibilityConverter}}">
                 <TextBlock
                   Margin="8,6,8,0"
@@ -568,6 +564,7 @@
 
               <StackPanel
                 x:Name="ProfileLoadPanel"
+                DockPanel.Dock="Top"
                 Visibility="{Binding IsRecordMode, Converter={StaticResource InvertedBoolToVisibilityConverter}}">
                 <TextBlock
                   Margin="8,8,8,0"
@@ -596,9 +593,21 @@
                     IsEnabled="{Binding InputControlsEnabled}" />
                 </Grid>
 
-                <TextBlock
-                  Margin="8,4,8,0"
-                  Text="Process executable binary" />
+                <Grid Margin="8,4,8,0">
+                  <TextBlock
+                    VerticalAlignment="Center"
+                    Text="Process executable binary" />
+                  <CheckBox
+                    x:Name="ExcludeIdleCheckBox"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Center"
+                    Content="Exclude Idle"
+                    IsChecked="{Binding ExcludeIdleProcess}"
+                    ToolTip="Hide the Idle process (PID 0) and recalculate weight percentages without it"
+                    Visibility="{Binding ShowProcessList, Converter={StaticResource BoolToVisibilityConverter}}"
+                    Checked="ExcludeIdleCheckBox_Changed"
+                    Unchecked="ExcludeIdleCheckBox_Changed" />
+                </Grid>
                 <Grid Margin="8,2,8,0">
                   <TextBox
                     x:Name="BinaryAutocompleteBox"
@@ -612,109 +621,7 @@
                 </Grid>
               </StackPanel>
 
-              <ListView
-                x:Name="ProcessList"
-                MinHeight="100"
-                MaxHeight="300"
-                Margin="8,4,8,0"
-                VerticalAlignment="Stretch"
-                Background="{DynamicResource {x:Static SystemColors.ControlLightLightBrushKey}}"
-                IsEnabled="{Binding ProcessListEnabled}"
-                ScrollViewer.VerticalScrollBarVisibility="Auto"
-                SelectionChanged="ProcessList_OnSelectionChanged"
-                SelectionMode="Extended"
-                VirtualizingStackPanel.IsVirtualizing="True"
-                VirtualizingStackPanel.VirtualizationMode="Recycling"
-                Visibility="{Binding ShowProcessList, Converter={StaticResource BoolToVisibilityConverter}}">
-                <ListView.View>
-                  <GridView>
-                    <GridViewColumn
-                      Width="150"
-                      DisplayMemberBinding="{Binding Process.Name}">
-                      <GridViewColumnHeader Name="ProcessNameColumn" Content="Process" />
-                      <GridViewColumn.HeaderContainerStyle>
-                        <Style TargetType="{x:Type GridViewColumnHeader}">
-                          <Setter Property="HorizontalContentAlignment" Value="Left" />
-                        </Style>
-                      </GridViewColumn.HeaderContainerStyle>
-                    </GridViewColumn>
-
-                    <GridViewColumn
-                      Width="80"
-                      DisplayMemberBinding="{Binding WeightPercentage, StringFormat={}{0:#0.00'%'}}">
-                      <GridViewColumnHeader Name="WeightPercentageColumn" Content="Weight" />
-                      <GridViewColumn.HeaderContainerStyle>
-                        <Style TargetType="{x:Type GridViewColumnHeader}">
-                          <Setter Property="HorizontalContentAlignment" Value="Left" />
-                        </Style>
-                      </GridViewColumn.HeaderContainerStyle>
-                    </GridViewColumn>
-
-                    <GridViewColumn
-                      Width="80"
-                      DisplayMemberBinding="{Binding Duration, StringFormat={}{0:mm\\:ss\\.ff}}">
-                      <GridViewColumnHeader Name="DurationColumn" Content="Duration" />
-                      <GridViewColumn.HeaderContainerStyle>
-                        <Style TargetType="{x:Type GridViewColumnHeader}">
-                          <Setter Property="HorizontalContentAlignment" Value="Left" />
-                        </Style>
-                      </GridViewColumn.HeaderContainerStyle>
-                    </GridViewColumn>
-
-                    <GridViewColumn
-                      Width="70"
-                      DisplayMemberBinding="{Binding Process.ProcessId}">
-                      <GridViewColumnHeader Name="ProcessIdColumn" Content="Process ID" />
-                      <GridViewColumn.HeaderContainerStyle>
-                        <Style TargetType="{x:Type GridViewColumnHeader}">
-                          <Setter Property="HorizontalContentAlignment" Value="Left" />
-                        </Style>
-                      </GridViewColumn.HeaderContainerStyle>
-                    </GridViewColumn>
-
-                    <GridViewColumn
-                      Width="150"
-                      DisplayMemberBinding="{Binding Process.CommandLine}">
-                      <GridViewColumnHeader Name="ProcessCommandLineColumn" Content="Command line" />
-                      <GridViewColumn.HeaderContainerStyle>
-                        <Style TargetType="{x:Type GridViewColumnHeader}">
-                          <Setter Property="HorizontalContentAlignment" Value="Left" />
-                        </Style>
-                      </GridViewColumn.HeaderContainerStyle>
-                    </GridViewColumn>
-                  </GridView>
-                </ListView.View>
-
-                <ListView.ItemContainerStyle>
-                  <Style
-                    BasedOn="{StaticResource FlatListViewItem}"
-                    TargetType="{x:Type ListViewItem}">
-                    <Setter Property="Background"
-                            Value="{DynamicResource {x:Static SystemColors.ControlLightLightBrushKey}}" />
-                    <Setter Property="ToolTip" Value="{Binding Process.CommandLine}" />
-                    <EventSetter
-                      Event="MouseDoubleClick"
-                      Handler="LoadButton_Click" />
-                    <EventSetter
-                      Event="PreviewKeyDown"
-                      Handler="ProcessList_PreviewKeyDown" />
-                  </Style>
-                </ListView.ItemContainerStyle>
-
-                <ListView.ContextMenu>
-                  <ContextMenu>
-                    <MenuItem
-                      Click="ProcessListMenuItem_OnClick"
-                      Header="Copy Process Details" />
-                    <MenuItem
-                      Click="ProcessListMenuItem_OnClick"
-                      Header="Copy Process List"
-                      IsEnabled="False" />
-                  </ContextMenu>
-                </ListView.ContextMenu>
-              </ListView>
-
-              <Grid Margin="8,8,8,4">
+              <Grid Margin="8,8,8,4" DockPanel.Dock="Bottom">
                 <StackPanel
                   Width="400"
                   HorizontalAlignment="Left">
@@ -765,7 +672,109 @@
                     Visibility="{Binding LoadingControlsVisible, Converter={StaticResource BoolToVisibilityConverter}}" />
                 </StackPanel>
               </Grid>
-            </StackPanel>
+
+              <ListView
+                x:Name="ProcessList"
+                MinHeight="100"
+                Margin="8,4,8,8"
+                VerticalAlignment="Stretch"
+                Background="{DynamicResource {x:Static SystemColors.ControlLightLightBrushKey}}"
+                IsEnabled="{Binding ProcessListEnabled}"
+                ScrollViewer.VerticalScrollBarVisibility="Auto"
+                SelectionChanged="ProcessList_OnSelectionChanged"
+                SelectionMode="Extended"
+                VirtualizingStackPanel.IsVirtualizing="True"
+                VirtualizingStackPanel.VirtualizationMode="Recycling"
+                Visibility="{Binding ShowProcessList, Converter={StaticResource BoolToVisibilityConverter}}">
+                <ListView.View>
+                  <GridView>
+                    <GridViewColumn
+                      Width="150"
+                      DisplayMemberBinding="{Binding Process.Name}">
+                      <GridViewColumnHeader Name="ProcessNameColumn" Content="Process" />
+                      <GridViewColumn.HeaderContainerStyle>
+                        <Style TargetType="{x:Type GridViewColumnHeader}">
+                          <Setter Property="HorizontalContentAlignment" Value="Left" />
+                        </Style>
+                      </GridViewColumn.HeaderContainerStyle>
+                    </GridViewColumn>
+
+                    <GridViewColumn
+                      x:Name="WeightColumn"
+                      Width="80"
+                      DisplayMemberBinding="{Binding WeightPercentageExcludingIdle, StringFormat={}{0:#0.00'%'}}">
+                      <GridViewColumnHeader Name="WeightPercentageColumn" Content="Weight" />
+                      <GridViewColumn.HeaderContainerStyle>
+                        <Style TargetType="{x:Type GridViewColumnHeader}">
+                          <Setter Property="HorizontalContentAlignment" Value="Left" />
+                        </Style>
+                      </GridViewColumn.HeaderContainerStyle>
+                    </GridViewColumn>
+
+                    <GridViewColumn
+                      Width="80"
+                      DisplayMemberBinding="{Binding Duration, StringFormat={}{0:mm\\:ss\\.ff}}">
+                      <GridViewColumnHeader Name="DurationColumn" Content="Duration" />
+                      <GridViewColumn.HeaderContainerStyle>
+                        <Style TargetType="{x:Type GridViewColumnHeader}">
+                          <Setter Property="HorizontalContentAlignment" Value="Left" />
+                        </Style>
+                      </GridViewColumn.HeaderContainerStyle>
+                    </GridViewColumn>
+
+                    <GridViewColumn
+                      Width="70"
+                      DisplayMemberBinding="{Binding Process.ProcessId}">
+                      <GridViewColumnHeader Name="ProcessIdColumn" Content="Process ID" />
+                      <GridViewColumn.HeaderContainerStyle>
+                        <Style TargetType="{x:Type GridViewColumnHeader}">
+                          <Setter Property="HorizontalContentAlignment" Value="Left" />
+                        </Style>
+                      </GridViewColumn.HeaderContainerStyle>
+                    </GridViewColumn>
+
+                    <GridViewColumn
+                      Width="500"
+                      DisplayMemberBinding="{Binding Process.CommandLine}">
+                      <GridViewColumnHeader Name="ProcessCommandLineColumn" Content="Command line" />
+                      <GridViewColumn.HeaderContainerStyle>
+                        <Style TargetType="{x:Type GridViewColumnHeader}">
+                          <Setter Property="HorizontalContentAlignment" Value="Left" />
+                        </Style>
+                      </GridViewColumn.HeaderContainerStyle>
+                    </GridViewColumn>
+                  </GridView>
+                </ListView.View>
+
+                <ListView.ItemContainerStyle>
+                  <Style
+                    BasedOn="{StaticResource FlatListViewItem}"
+                    TargetType="{x:Type ListViewItem}">
+                    <Setter Property="Background"
+                            Value="{DynamicResource {x:Static SystemColors.ControlLightLightBrushKey}}" />
+                    <Setter Property="ToolTip" Value="{Binding Process.CommandLine}" />
+                    <EventSetter
+                      Event="MouseDoubleClick"
+                      Handler="LoadButton_Click" />
+                    <EventSetter
+                      Event="PreviewKeyDown"
+                      Handler="ProcessList_PreviewKeyDown" />
+                  </Style>
+                </ListView.ItemContainerStyle>
+
+                <ListView.ContextMenu>
+                  <ContextMenu>
+                    <MenuItem
+                      Click="ProcessListMenuItem_OnClick"
+                      Header="Copy Process Details" />
+                    <MenuItem
+                      Click="ProcessListMenuItem_OnClick"
+                      Header="Copy Process List"
+                      IsEnabled="False" />
+                  </ContextMenu>
+                </ListView.ContextMenu>
+              </ListView>
+            </DockPanel>
           </TabItem>
 
           <TabItem
@@ -784,6 +793,7 @@
             Header="Options"
             IsEnabled="{Binding InputControlsEnabled}"
             Style="{StaticResource TabControlStyle}">
+            <ScrollViewer VerticalScrollBarVisibility="Auto">
             <StackPanel
               Margin="0,4,0,8"
               Orientation="Vertical">
@@ -904,6 +914,7 @@
                 </StackPanel>
               </Expander>
             </StackPanel>
+            </ScrollViewer>
           </TabItem>
           <TabItem
             Header="CPU counters"
@@ -1252,7 +1263,6 @@
             </Grid>
           </TabItem>
         </TabControl>
-      </ScrollViewer>
     </DockPanel>
   </Grid>
 </Window>

--- a/src/ProfileExplorerUI/Windows/ProfileLoadWindow.xaml.cs
+++ b/src/ProfileExplorerUI/Windows/ProfileLoadWindow.xaml.cs
@@ -751,7 +751,7 @@ public partial class ProfileLoadWindow : Window, INotifyPropertyChanged {
     };
 
     if (excludeIdleProcess_) {
-      view.Filter = item => ((ProcessSummary)item).Process.ProcessId != 0;
+      view.Filter = item => ((ProcessSummary)item).Process.ProcessId != ETWEventProcessor.KernelProcessId;
     }
     else {
       view.Filter = null;

--- a/src/ProfileExplorerUI/Windows/ProfileLoadWindow.xaml.cs
+++ b/src/ProfileExplorerUI/Windows/ProfileLoadWindow.xaml.cs
@@ -54,6 +54,7 @@ public partial class ProfileLoadWindow : Window, INotifyPropertyChanged {
   private string profileFilePath_;
   private string binaryFilePath_;
   private bool showOnlyManagedProcesses_;
+  private bool excludeIdleProcess_ = true;
   private bool showLoadingProgress_;
   private bool openLoadedSession_;
   private double lastProgressPercentage_ = 0;
@@ -223,6 +224,16 @@ public partial class ProfileLoadWindow : Window, INotifyPropertyChanged {
       if (showOnlyManagedProcesses_ != value) {
         showOnlyManagedProcesses_ = value;
         UpdateRunningProcessList();
+      }
+    }
+  }
+
+  public bool ExcludeIdleProcess {
+    get => excludeIdleProcess_;
+    set {
+      if (excludeIdleProcess_ != value) {
+        excludeIdleProcess_ = value;
+        OnPropertyChange(nameof(ExcludeIdleProcess));
       }
     }
   }
@@ -715,9 +726,12 @@ public partial class ProfileLoadWindow : Window, INotifyPropertyChanged {
 
   private void DisplayProcessList(List<ProcessSummary> list, List<ProcessSummary> selectedProcSummary = null) {
     ProcessList.ItemsSource = null;
-    ProcessList.ItemsSource = new ListCollectionView(list);
+    var view = new ListCollectionView(list);
+    ProcessList.ItemsSource = view;
     ShowProcessList = true;
-    
+
+    ApplyIdleFilter(view);
+
     // Set default sort by weight (highest first) to maintain current behavior
     processListSorter_.SortByField(ProcessSortField.Weight, ListSortDirection.Descending);
 
@@ -726,6 +740,27 @@ public partial class ProfileLoadWindow : Window, INotifyPropertyChanged {
       foreach (var proc in selectedProcSummary) {
         ProcessList.SelectedItems.Add(list.Find(item => item.Process == proc.Process));
       }
+    }
+  }
+
+  private void ApplyIdleFilter(ListCollectionView view) {
+    // Update the weight column binding based on the exclude-idle toggle.
+    string bindingPath = excludeIdleProcess_ ? "WeightPercentageExcludingIdle" : "WeightPercentage";
+    WeightColumn.DisplayMemberBinding = new System.Windows.Data.Binding(bindingPath) {
+      StringFormat = "{0:#0.00'%'}"
+    };
+
+    if (excludeIdleProcess_) {
+      view.Filter = item => ((ProcessSummary)item).Process.ProcessId != 0;
+    }
+    else {
+      view.Filter = null;
+    }
+  }
+
+  private void ExcludeIdleCheckBox_Changed(object sender, RoutedEventArgs e) {
+    if (ProcessList.ItemsSource is ListCollectionView view) {
+      ApplyIdleFilter(view);
     }
   }
 


### PR DESCRIPTION
This pull request improves how process weights are calculated and displayed in the profile loading UI, especially regarding the "Idle" process. It introduces a new weight percentage that excludes the Idle process, updates the backend to support this calculation, and modifies the UI to allow users to toggle the exclusion of Idle. Additionally, it streamlines the process information extraction logic and makes several UI layout improvements.

**Backend logic and data model changes:**

* Added `WeightPercentageExcludingIdle` to the `ProcessSummary` data model to represent process weight percentages calculated without the Idle process.
* Updated `ProcessSummaryBuilder` to use process IDs as dictionary keys, calculate non-idle total weights, and populate the new `WeightPercentageExcludingIdle` field. [[1]](diffhunk://#diff-38d0a0bf8bbf20f1c1035a653f0aba4284ac202e8c92d58d0390fcbcce57bcb0L12-R13) [[2]](diffhunk://#diff-38d0a0bf8bbf20f1c1035a653f0aba4284ac202e8c92d58d0390fcbcce57bcb0L22-R28) [[3]](diffhunk://#diff-38d0a0bf8bbf20f1c1035a653f0aba4284ac202e8c92d58d0390fcbcce57bcb0L37-R43) [[4]](diffhunk://#diff-38d0a0bf8bbf20f1c1035a653f0aba4284ac202e8c92d58d0390fcbcce57bcb0R55-R70)

**UI and process list improvements:**

* Modified the process list in `ProfileLoadWindow.xaml` to display `WeightPercentageExcludingIdle` instead of the original percentage and added a checkbox to allow users to exclude or include the Idle process in calculations. [[1]](diffhunk://#diff-f7b74989f636ab542dfcb55cb118e9ed7d2b8b2a1ab5bcab87df74dc864b3ebaR596-R610) [[2]](diffhunk://#diff-f7b74989f636ab542dfcb55cb118e9ed7d2b8b2a1ab5bcab87df74dc864b3ebaR703-R705)
* Enhanced the UI layout for better usability, including moving controls, resizing columns, and improving progress indicator placement. [[1]](diffhunk://#diff-f7b74989f636ab542dfcb55cb118e9ed7d2b8b2a1ab5bcab87df74dc864b3ebaL148-R146) [[2]](diffhunk://#diff-f7b74989f636ab542dfcb55cb118e9ed7d2b8b2a1ab5bcab87df74dc864b3ebaR567) [[3]](diffhunk://#diff-f7b74989f636ab542dfcb55cb118e9ed7d2b8b2a1ab5bcab87df74dc864b3ebaL676-R737) [[4]](diffhunk://#diff-f7b74989f636ab542dfcb55cb118e9ed7d2b8b2a1ab5bcab87df74dc864b3ebaR624-R679) [[5]](diffhunk://#diff-f7b74989f636ab542dfcb55cb118e9ed7d2b8b2a1ab5bcab87df74dc864b3ebaR796) [[6]](diffhunk://#diff-f7b74989f636ab542dfcb55cb118e9ed7d2b8b2a1ab5bcab87df74dc864b3ebaR917) [[7]](diffhunk://#diff-f7b74989f636ab542dfcb55cb118e9ed7d2b8b2a1ab5bcab87df74dc864b3ebaL1255) [[8]](diffhunk://#diff-f7b74989f636ab542dfcb55cb118e9ed7d2b8b2a1ab5bcab87df74dc864b3ebaL137-L139) [[9]](diffhunk://#diff-f7b74989f636ab542dfcb55cb118e9ed7d2b8b2a1ab5bcab87df74dc864b3ebaL716-L768) [[10]](diffhunk://#diff-f7b74989f636ab542dfcb55cb118e9ed7d2b8b2a1ab5bcab87df74dc864b3ebaL18-L22) [[11]](diffhunk://#diff-f7b74989f636ab542dfcb55cb118e9ed7d2b8b2a1ab5bcab87df74dc864b3ebaL716-L768) [[12]](diffhunk://#diff-f7b74989f636ab542dfcb55cb118e9ed7d2b8b2a1ab5bcab87df74dc864b3ebaL18-L22) [[13]](diffhunk://#diff-f7b74989f636ab542dfcb55cb118e9ed7d2b8b2a1ab5bcab87df74dc864b3ebaL716-L768)
* Updated `McpActionExecutor` to extract process summaries directly (bypassing the UI window), filter out the Idle process, and use the new non-idle weight percentages for process filtering and display.

**Code cleanup:**

* Removed the now-unnecessary `ExtractProcessInfoAsync` method from `McpActionExecutor`, as process information is now obtained directly from the backend.