### PR TITLE
fix: copy msdia140.dll to build output root

### DIFF
--- a/src/ProfileExplorerUI/ProfileExplorerUI.csproj
+++ b/src/ProfileExplorerUI/ProfileExplorerUI.csproj
@@ -325,13 +325,13 @@
 	</ItemGroup>
 
 	<!-- Copy msdia140.dll to output root so COM registration path (AppContext.BaseDirectory) works -->
-	<ItemGroup Condition="'$(PlatformTarget)' == 'ARM64'">
+	<ItemGroup Condition="'$(Platform)' == 'ARM64'">
 		<Content Include="..\external\arm64\msdia140.dll">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<Link>msdia140.dll</Link>
 		</Content>
 	</ItemGroup>
-	<ItemGroup Condition="'$(PlatformTarget)' != 'ARM64'">
+	<ItemGroup Condition="'$(Platform)' != 'ARM64'">
 		<Content Include="..\external\msdia140.dll">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<Link>msdia140.dll</Link>

--- a/src/ProfileExplorerUI/ProfileExplorerUI.csproj
+++ b/src/ProfileExplorerUI/ProfileExplorerUI.csproj
@@ -324,5 +324,19 @@
 		</Reference>
 	</ItemGroup>
 
+	<!-- Copy msdia140.dll to output root so COM registration path (AppContext.BaseDirectory) works -->
+	<ItemGroup Condition="'$(PlatformTarget)' == 'ARM64'">
+		<Content Include="..\external\arm64\msdia140.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Link>msdia140.dll</Link>
+		</Content>
+	</ItemGroup>
+	<ItemGroup Condition="'$(PlatformTarget)' != 'ARM64'">
+		<Content Include="..\external\msdia140.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Link>msdia140.dll</Link>
+		</Content>
+	</ItemGroup>
+
 
 </Project>


### PR DESCRIPTION
msdia140.dll was only landing in amd64/arm64/x86 subdirectories (via the TraceEvent.SupportFiles NuGet package) but PDBDebugInfoProvider references it at AppContext.BaseDirectory for COM registration via regsvr32.

Add Content items to ProfileExplorerUI.csproj to copy the correct arch variant (src/external/msdia140.dll for x64, src/external/arm64/msdia140.dll for ARM64) to the output root. The installer already handled this via xcopy in prepare-out.cmd, but regular dev builds did not.