### PR TITLE
Enhance binary lookup and Azure DevOps authentication for source downloads

### DIFF
--- a/src/PDBViewer/PDBViewer.csproj
+++ b/src/PDBViewer/PDBViewer.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.28" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.30" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="1.0.23" />
   </ItemGroup>
 

--- a/src/ProfileExplorerCore/Binary/PDBDebugInfoProvider.cs
+++ b/src/ProfileExplorerCore/Binary/PDBDebugInfoProvider.cs
@@ -34,6 +34,7 @@ public sealed class PDBDebugInfoProvider : IDebugInfoProvider {
   private static ConcurrentDictionary<SymbolFileDescriptor, DebugFileSearchResult> resolvedSymbolsCache_ = new();
   private static readonly StringWriter authLogWriter_;
   private static readonly SymwebHandler authSymwebHandler_;
+  private static readonly AzureDevOpsSourceHandler authAzDevOpsHandler_;
   private static readonly string authRecordPath_ = Path.Combine(Path.GetTempPath(), "ProfileExplorer", "auth_record.bin");
   private static object undecorateLock_ = new(); // Global lock for undname.
   private ConcurrentDictionary<long, SourceFileDebugInfo> sourceFileByRvaCache_ = new();
@@ -119,6 +120,7 @@ public sealed class PDBDebugInfoProvider : IDebugInfoProvider {
 
     authLogWriter_ = new StringWriter();
     authSymwebHandler_ = new SymwebHandler(authLogWriter_, authCredential);
+    authAzDevOpsHandler_ = new AzureDevOpsSourceHandler(authLogWriter_, authCredential);
   }
 
   /// <summary>
@@ -414,6 +416,7 @@ public sealed class PDBDebugInfoProvider : IDebugInfoProvider {
   public static SymbolReaderAuthenticationHandler CreateAuthHandler(SymbolFileSourceSettings settings) {
     var authHandler = new SymbolReaderAuthenticationHandler();
     authHandler.AddHandler(authSymwebHandler_);
+    authHandler.AddHandler(authAzDevOpsHandler_);
 
     if (settings.AuthorizationTokenEnabled) {
       authHandler.AddHandler(new BasicAuthenticationHandler(settings, authLogWriter_));
@@ -1292,6 +1295,49 @@ public sealed class PDBDebugInfoProvider : IDebugInfoProvider {
     }
     catch (Exception ex) {
       Trace.TraceError($"Failed to get function symbol for {functionName}: {ex.Message}");
+      return null;
+    }
+  }
+}
+
+/// <summary>
+/// Handles Azure AD authentication for Azure DevOps source server URLs.
+/// The source server for Windows OS PDBs uses Azure DevOps (*.visualstudio.com, dev.azure.com),
+/// which requires a Bearer token with the Azure DevOps scope.
+/// </summary>
+sealed class AzureDevOpsSourceHandler : SymbolReaderAuthHandler {
+  private const string AzureDevOpsScope = "499b84ac-1321-427f-aa17-267ca6975798/.default";
+  private readonly TokenCredential credential_;
+
+  public AzureDevOpsSourceHandler(TextWriter log, TokenCredential credential) :
+    base(log, "AzureDevOps Source") {
+    credential_ = credential;
+  }
+
+  protected override bool TryGetAuthority(Uri requestUri, out Uri authority) {
+    string host = requestUri.Host;
+
+    if (host.EndsWith(".visualstudio.com", StringComparison.OrdinalIgnoreCase) ||
+        host.EndsWith("dev.azure.com", StringComparison.OrdinalIgnoreCase)) {
+      authority = new Uri($"{requestUri.Scheme}://{requestUri.Host}");
+      return true;
+    }
+
+    authority = null;
+    return false;
+  }
+
+  protected override async Task<AuthToken?> GetAuthTokenAsync(RequestContext context,
+                                                               SymbolReaderHandlerDelegate next,
+                                                               Uri authority,
+                                                               CancellationToken cancellationToken) {
+    try {
+      var tokenRequest = new TokenRequestContext(new[] { AzureDevOpsScope });
+      var accessToken = await credential_.GetTokenAsync(tokenRequest, cancellationToken);
+      return new AuthToken(AuthScheme.Bearer, accessToken.Token, accessToken.ExpiresOn.UtcDateTime, null);
+    }
+    catch (Exception ex) {
+      WriteLog($"AzureDevOps auth failed: {ex.Message}");
       return null;
     }
   }

--- a/src/ProfileExplorerCore/Binary/PEBinaryInfoProvider.cs
+++ b/src/ProfileExplorerCore/Binary/PEBinaryInfoProvider.cs
@@ -273,7 +273,9 @@ public sealed class PEBinaryInfoProvider : IBinaryInfoProvider, IDisposable {
     }
 
     // Quick check if trace was recorded on local machine.
-    string result = FindExactLocalBinaryFile(binaryFile);
+    string approximateMatchPath = null;
+    long correctedImageSize = 0;
+    string result = FindExactLocalBinaryFile(binaryFile, out approximateMatchPath, out correctedImageSize);
 
     if (result != null) {
       DiagnosticLogger.LogInfo($"[BinarySearch] Found exact local binary for {binaryFile.ImageName} at {result} ({sw.ElapsedMilliseconds}ms)");
@@ -281,6 +283,18 @@ public sealed class PEBinaryInfoProvider : IBinaryInfoProvider, IDisposable {
       searchResult = BinaryFileSearchResult.Success(binaryFile, result, "");
       resolvedBinariesCache_.TryAdd(binaryFile, searchResult);
       return searchResult;
+    }
+
+    // Correct ImageSize if the file exists locally with matching timestamp but
+    // different size. The symbol server indexes binaries by TimeDateStamp+SizeOfImage
+    // from the PE header, but the ETW kernel event may report a larger mapped view size
+    // (the kernel mapping can include extra slack pages). Using the wrong size causes
+    // 404s on the symbol server even when the binary IS indexed there.
+    if (correctedImageSize > 0 && correctedImageSize != binaryFile.ImageSize) {
+      DiagnosticLogger.LogInfo(
+        $"[BinarySearch] Correcting ImageSize for {binaryFile.ImageName} from ETW value {binaryFile.ImageSize} " +
+        $"to PE SizeOfImage {correctedImageSize} for symbol server lookup");
+      binaryFile.ImageSize = correctedImageSize;
     }
 
     using var logWriter = new StringWriter();
@@ -324,7 +338,7 @@ public sealed class PEBinaryInfoProvider : IBinaryInfoProvider, IDisposable {
       if (result == null) {
         // Finally, try an approximate manual search.
         DiagnosticLogger.LogDebug($"[BinarySearch] Symbol server search failed, trying approximate local search for {binaryFile.ImageName}");
-        result = FindMatchingLocalBinaryFile(binaryFile, settings);
+        result = FindMatchingLocalBinaryFile(binaryFile, settings, ref approximateMatchPath);
       }
     }
     catch (Exception ex) {
@@ -346,6 +360,21 @@ public sealed class PEBinaryInfoProvider : IBinaryInfoProvider, IDisposable {
       // Read the binary info from the local file to fill in all fields.
       binaryFile = GetBinaryFileInfo(result);
       searchResult = BinaryFileSearchResult.Success(binaryFile, result, searchLog);
+    }
+    else if (settings.AllowApproximateBinaryMatch &&
+             !string.IsNullOrEmpty(approximateMatchPath) &&
+             File.Exists(approximateMatchPath)) {
+      // Fallback: use a binary with matching timestamp but different size.
+      // This handles cases where the kernel-reported ImageSize in the ETW trace
+      // differs from the PE header SizeOfImage, or the DLL was serviced.
+      DiagnosticLogger.LogWarning(
+        $"[BinarySearch] Using APPROXIMATE match for {binaryFile.ImageName} " +
+        $"at {approximateMatchPath} ({searchDuration.TotalMilliseconds:F0}ms) - " +
+        $"timestamp matches but image size differs");
+      binaryFile = GetBinaryFileInfo(approximateMatchPath);
+      string details = $"Approximate match: timestamp matches but image size differs " +
+        $"(trace: {binaryFile.ImageSize}). Disassembly may not be fully accurate.\n{searchLog}";
+      searchResult = BinaryFileSearchResult.ApproximateSuccess(binaryFile, approximateMatchPath, details);
     }
     else {
       DiagnosticLogger.LogWarning($"[BinarySearch] Failed to find binary for {binaryFile.ImageName} ({searchDuration.TotalMilliseconds:F0}ms)");
@@ -374,14 +403,31 @@ public sealed class PEBinaryInfoProvider : IBinaryInfoProvider, IDisposable {
     return path;
   }
 
-  private static string FindExactLocalBinaryFile(BinaryFileDescriptor binaryFile) {
+  private static string FindExactLocalBinaryFile(BinaryFileDescriptor binaryFile,
+                                                  out string approximateMatchPath,
+                                                  out long correctedImageSize) {
+    approximateMatchPath = null;
+    correctedImageSize = 0;
+
     if (File.Exists(binaryFile.ImagePath)) {
       var fileInfo = GetBinaryFileInfo(binaryFile.ImagePath);
 
-      if (fileInfo != null &&
-          fileInfo.TimeStamp == binaryFile.TimeStamp &&
-          fileInfo.ImageSize == binaryFile.ImageSize) {
-        return binaryFile.ImagePath;
+      if (fileInfo != null && fileInfo.TimeStamp == binaryFile.TimeStamp) {
+        if (fileInfo.ImageSize == binaryFile.ImageSize) {
+          return binaryFile.ImagePath;
+        }
+
+        // Timestamp matches but size differs. This commonly happens because the
+        // kernel-reported ImageSize in ETW events is the mapped view size, which
+        // can exceed the PE header's SizeOfImage by a few pages of slack.
+        // Record the local file as an approximate match and save the PE SizeOfImage
+        // so we can correct the symbol server lookup key.
+        approximateMatchPath = binaryFile.ImagePath;
+        correctedImageSize = fileInfo.ImageSize;
+        DiagnosticLogger.LogInfo(
+          $"[BinarySearch] Local binary for {binaryFile.ImageName} at {binaryFile.ImagePath}: " +
+          $"timestamp matches ({fileInfo.TimeStamp}), size differs " +
+          $"(PE SizeOfImage: {fileInfo.ImageSize}, ETW ImageSize: {binaryFile.ImageSize})");
       }
     }
 
@@ -389,7 +435,8 @@ public sealed class PEBinaryInfoProvider : IBinaryInfoProvider, IDisposable {
   }
 
   private static string FindMatchingLocalBinaryFile(BinaryFileDescriptor binaryFile,
-                                                    SymbolFileSourceSettings settings) {
+                                                    SymbolFileSourceSettings settings,
+                                                    ref string approximateMatchPath) {
     // Manually search in the provided directories.
     // This helps in cases where the original fine name doesn't match
     // the one on disk, like it seems to happen sometimes with the SPEC runner.
@@ -421,10 +468,18 @@ public sealed class PEBinaryInfoProvider : IBinaryInfoProvider, IDisposable {
 
           var fileInfo = GetBinaryFileInfo(file);
 
-          if (fileInfo != null &&
-              fileInfo.TimeStamp == binaryFile.TimeStamp &&
-              fileInfo.ImageSize == binaryFile.ImageSize) {
-            return file;
+          if (fileInfo != null && fileInfo.TimeStamp == binaryFile.TimeStamp) {
+            if (fileInfo.ImageSize == binaryFile.ImageSize) {
+              return file;
+            }
+
+            // Track first approximate match (timestamp matches, size differs).
+            if (approximateMatchPath == null) {
+              approximateMatchPath = file;
+              DiagnosticLogger.LogInfo(
+                $"[BinarySearch] Approximate match for {binaryFile.ImageName} in search paths: " +
+                $"{file} (on-disk: {fileInfo.ImageSize}, trace: {binaryFile.ImageSize})");
+            }
           }
         }
       }

--- a/src/ProfileExplorerCore/Binary/PEBinaryInfoProvider.cs
+++ b/src/ProfileExplorerCore/Binary/PEBinaryInfoProvider.cs
@@ -367,14 +367,19 @@ public sealed class PEBinaryInfoProvider : IBinaryInfoProvider, IDisposable {
       // Fallback: use a binary with matching timestamp but different size.
       // This handles cases where the kernel-reported ImageSize in the ETW trace
       // differs from the PE header SizeOfImage, or the DLL was serviced.
+      long traceImageSize = binaryFile.ImageSize;
+      var originalDescriptor = binaryFile;
       DiagnosticLogger.LogWarning(
         $"[BinarySearch] Using APPROXIMATE match for {binaryFile.ImageName} " +
         $"at {approximateMatchPath} ({searchDuration.TotalMilliseconds:F0}ms) - " +
         $"timestamp matches but image size differs");
       binaryFile = GetBinaryFileInfo(approximateMatchPath);
       string details = $"Approximate match: timestamp matches but image size differs " +
-        $"(trace: {binaryFile.ImageSize}). Disassembly may not be fully accurate.\n{searchLog}";
+        $"(trace: {traceImageSize}, on-disk: {binaryFile.ImageSize}). Disassembly may not be fully accurate.\n{searchLog}";
       searchResult = BinaryFileSearchResult.ApproximateSuccess(binaryFile, approximateMatchPath, details);
+      // Cache under the original trace descriptor so subsequent lookups for the
+      // same trace module hit the cache instead of repeating the search.
+      resolvedBinariesCache_.TryAdd(originalDescriptor, searchResult);
     }
     else {
       DiagnosticLogger.LogWarning($"[BinarySearch] Failed to find binary for {binaryFile.ImageName} ({searchDuration.TotalMilliseconds:F0}ms)");

--- a/src/ProfileExplorerCore/Profile/ETW/ETWEventProcessor.cs
+++ b/src/ProfileExplorerCore/Profile/ETW/ETWEventProcessor.cs
@@ -275,6 +275,12 @@ public sealed partial class ETWEventProcessor : IDisposable {
         if (lastProfileImage.TimeStamp == 0) {
           lastProfileImage.TimeStamp = data.TimeDateStamp;
         }
+
+        // Prefer ImageSize from ImageID (PE header value from merge) over the kernel
+        // ImageGroup value (mapped view size which can have extra slack pages).
+        if (data.ImageSize > 0) {
+          lastProfileImage.Size = (int)data.ImageSize;
+        }
       }
       else {
         // The ImageGroup event should show up later in the stream.
@@ -346,6 +352,7 @@ public sealed partial class ETWEventProcessor : IDisposable {
       imageLoadEventCount++;
       string originalName = null;
       int timeStamp = data.TimeDateStamp;
+      int imageSize = data.ImageSize;
       bool sawImageId = false;
 
       if (lastImageIdData != null && lastImageIdData.TimeStampQPC == data.TimeStampQPC) {
@@ -355,6 +362,15 @@ public sealed partial class ETWEventProcessor : IDisposable {
 
         if (timeStamp == 0) {
           timeStamp = lastImageIdData.TimeDateStamp;
+        }
+
+        // Prefer the ImageSize from the ImageID event over the kernel ImageGroup event.
+        // The kernel reports the mapped view size which can exceed the PE SizeOfImage
+        // by a few slack pages. The ImageID event's ImageSize comes from reading the
+        // actual PE file during trace merge, so it matches the PE header and is the
+        // correct value for symbol server lookups (TimeDateStamp+SizeOfImage key).
+        if (lastImageIdData.ImageSize > 0) {
+          imageSize = (int)lastImageIdData.ImageSize;
         }
       }
       else if (isRealTime_) {
@@ -372,7 +388,7 @@ public sealed partial class ETWEventProcessor : IDisposable {
 #endif
 
       var image = new ProfileImage(data.FileName, originalName, (long)data.ImageBase,
-                                   (long)data.DefaultBase, data.ImageSize,
+                                   (long)data.DefaultBase, imageSize,
                                    timeStamp, data.ImageChecksum);
       if (timeStamp != 0) {
         imageLoadWithTimestampCount++;

--- a/src/ProfileExplorerCore/ProfileExplorerCore.csproj
+++ b/src/ProfileExplorerCore/ProfileExplorerCore.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Google.Protobuf" Version="3.28.3" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.68" />
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="4.0.0-beta.24314.3" />
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.28" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.30" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="1.0.23" />
     <PackageReference Include="protobuf-net" Version="3.2.45" />
   </ItemGroup>

--- a/src/ProfileExplorerCore/Providers/ICompilerInfoProvider.cs
+++ b/src/ProfileExplorerCore/Providers/ICompilerInfoProvider.cs
@@ -41,6 +41,8 @@ public class BinaryFileSearchResult {
   public string FilePath { get; set; }
   [ProtoMember(4)]
   public string Details { get; set; }
+  [ProtoMember(5)]
+  public bool IsApproximateMatch { get; set; }
 
   public static BinaryFileSearchResult Success(BinaryFileDescriptor file, string filePath, string details = null) {
     return new BinaryFileSearchResult {Found = true, BinaryFile = file, FilePath = filePath, Details = details};
@@ -53,6 +55,10 @@ public class BinaryFileSearchResult {
     }
 
     return new BinaryFileSearchResult {Found = false, BinaryFile = null, FilePath = filePath};
+  }
+
+  public static BinaryFileSearchResult ApproximateSuccess(BinaryFileDescriptor file, string filePath, string details = null) {
+    return new BinaryFileSearchResult {Found = true, BinaryFile = file, FilePath = filePath, Details = details, IsApproximateMatch = true};
   }
 
   public static BinaryFileSearchResult Failure(BinaryFileDescriptor file, string details) {

--- a/src/ProfileExplorerCore/Settings/SymbolFileSourceSettings.cs
+++ b/src/ProfileExplorerCore/Settings/SymbolFileSourceSettings.cs
@@ -83,6 +83,8 @@ public class SymbolFileSourceSettings : SettingsBase {
   public DateTime RejectedFilesCacheTime { get; set; }
   [ProtoMember(23)][OptionValue(3)] // 3 days default expiration
   public int RejectedFilesCacheExpirationDays { get; set; }
+  [ProtoMember(25)][OptionValue(true)]
+  public bool AllowApproximateBinaryMatch { get; set; }
   public bool HasAuthorizationToken => AuthorizationTokenEnabled && !string.IsNullOrEmpty(AuthorizationToken);
   public bool HasCompanyFilter => CompanyFilterEnabled;
 

--- a/src/ProfileExplorerUI/Document/IRDocument.cs
+++ b/src/ProfileExplorerUI/Document/IRDocument.cs
@@ -438,6 +438,10 @@ public sealed class IRDocument : TextEditor, INotifyPropertyChanged {
 
   public void BringElementIntoView(IRElement op,
                                    BringIntoViewStyle style = BringIntoViewStyle.Default) {
+    if (op.TextLocation.Offset < 0 || op.TextLocation.Offset >= Document.TextLength) {
+      return;
+    }
+
     ignoreNextHoverEvent_ = true;
     ignoreNextCaretEvent_ = true;
     int line = Document.GetLineByOffset(op.TextLocation.Offset).LineNumber;

--- a/src/ProfileExplorerUI/OptionsPanels/SymbolOptionsPanel.xaml
+++ b/src/ProfileExplorerUI/OptionsPanels/SymbolOptionsPanel.xaml
@@ -59,6 +59,11 @@
       </StackPanel>
       <CheckBox
         Margin="0,4,0,0"
+        Content="Allow approximate binary match (matching timestamp, different size)"
+        IsChecked="{Binding Path=AllowApproximateBinaryMatch, Mode=TwoWay}"
+        ToolTip="When a binary file is found with a matching timestamp but different image size, use it as a fallback for disassembly. This helps when the kernel-reported image size differs from the PE header, or when a DLL was serviced." />
+      <CheckBox
+        Margin="0,4,0,0"
         Content="Don't load symbols that failed in previous sessions"
         IsChecked="{Binding Path=RejectPreviouslyFailedFiles, Mode=TwoWay}"
         ToolTip="Skip downloading and loading of symbols that could not be found in previous sessions" />

--- a/src/ProfileExplorerUI/ProfileExplorerUI.csproj
+++ b/src/ProfileExplorerUI/ProfileExplorerUI.csproj
@@ -167,7 +167,7 @@
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.11.0" />
 		<PackageReference Include="Microsoft.Diagnostics.Runtime" Version="4.0.0-beta.24314.3" />
-		<PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.28" />
+		<PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.30" />
 		<PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent.SupportFiles" Version="1.0.23" />
 		<PackageReference Include="Microsoft.VisualStudio.SDK.Analyzers" Version="17.7.47">
 			<PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This pull request improves binary file matching and symbol server authentication in the Profile Explorer. Especially for Windows ETW traces where kernel-reported image sizes may differ from the PE header (random) and would cause dissassembly to not load. Implements Azure DevOps authentication for source server access. It also brings alterate source link support.  Last it introduces fallback logic to use binaries with matching timestamps but different sizes, adds user-configurable options for approximate matches.



**ETW event processing improvements:**

* Modified ETW event processing to prefer the image size from the ImageID event (which matches the PE header) over the kernel's mapped view size, ensuring more accurate symbol server lookups and reducing mismatches. This fixes some sources of assembly/dissassembly not loading due to missing binary load [[1]](diffhunk://#diff-60389829a3da56fb0b9744f56da27738cbebf0f98c17ab24a0857f9fb75a1ae2R278-R283) [[2]](diffhunk://#diff-60389829a3da56fb0b9744f56da27738cbebf0f98c17ab24a0857f9fb75a1ae2R355) [[3]](diffhunk://#diff-60389829a3da56fb0b9744f56da27738cbebf0f98c17ab24a0857f9fb75a1ae2R366-R374) [[4]](diffhunk://#diff-60389829a3da56fb0b9744f56da27738cbebf0f98c17ab24a0857f9fb75a1ae2L375-R391)

**Symbol server authentication enhancements:**

* Implemented a new `AzureDevOpsSourceHandler` for Azure AD authentication, enabling access to source server URLs hosted on Azure DevOps that require Bearer tokens. Integrated this handler into the authentication pipeline for symbol file retrieval. [[1]](diffhunk://#diff-7eed16ee99fc90f2dcfca3ef5193a6d4fb6af6c9873deec97c7932d28eca1750R37) [[2]](diffhunk://#diff-7eed16ee99fc90f2dcfca3ef5193a6d4fb6af6c9873deec97c7932d28eca1750R123) [[3]](diffhunk://#diff-7eed16ee99fc90f2dcfca3ef5193a6d4fb6af6c9873deec97c7932d28eca1750R419) [[4]](diffhunk://#diff-7eed16ee99fc90f2dcfca3ef5193a6d4fb6af6c9873deec97c7932d28eca1750R1303-R1345)

**Dependency updates:**

* Updated the `Microsoft.Diagnostics.Tracing.TraceEvent` NuGet package from version 3.1.28 to 3.1.30 across all relevant projects which has sourceLink support found in some pdbs necessary to fetch source code. [[1]](diffhunk://#diff-c8cf252d4016eab07911a41b496fd2bd95d1e9e992bd0d9c1ce87e153d5ad15fL16-R16) [[2]](diffhunk://#diff-e193d01e63815dd33d6143636765077b97a9c9734befb2e9f4ea41be5d59bc91L18-R18) [[3]](diffhunk://#diff-33db56ce7d8e32013142bd61ea1365bdb596460517d439822a97e9e66e6c2fb5L170-R170)

**Binary file matching improvements:**

* Enhanced the binary search logic to allow approximate matches when a binary with a matching timestamp but different image size is found, addressing common issues where the kernel-reported image size differs from the PE header. This includes correcting the image size for symbol server lookups and providing detailed logging and warnings when approximate matches are used. [[1]](diffhunk://#diff-de46330d53bec9e95a70e2d25aef33ac1a7b69269f1f7c48a9eb4b599d7e15e0L276-R278) [[2]](diffhunk://#diff-de46330d53bec9e95a70e2d25aef33ac1a7b69269f1f7c48a9eb4b599d7e15e0R288-R299) [[3]](diffhunk://#diff-de46330d53bec9e95a70e2d25aef33ac1a7b69269f1f7c48a9eb4b599d7e15e0R364-R378) [[4]](diffhunk://#diff-de46330d53bec9e95a70e2d25aef33ac1a7b69269f1f7c48a9eb4b599d7e15e0L377-R439) [[5]](diffhunk://#diff-de46330d53bec9e95a70e2d25aef33ac1a7b69269f1f7c48a9eb4b599d7e15e0L424-R483) [[6]](diffhunk://#diff-9a106c13e1088fd37fa446b8fee6e4c1ae2d51b042200f47735549d189955c1bR44-R45) [[7]](diffhunk://#diff-9a106c13e1088fd37fa446b8fee6e4c1ae2d51b042200f47735549d189955c1bR60-R63)

* Added a new setting `AllowApproximateBinaryMatch` to the `SymbolFileSourceSettings` class, exposed in the UI, allowing users to enable or disable the use of approximate binary matches. [[1]](diffhunk://#diff-52576f93a71711a91abf7eb767194c63fa2674886b3aa4d684a801298d5aa9ffR86-R87) [[2]](diffhunk://#diff-741d92a54b624e25786eb13977744043a4dad4982b78dba6ef75ada3c682ca62R60-R64)