### PR TITLE
fix: copy native deps to build output and fix installer regsvr32 bitness

### DIFF
--- a/installer/arm64/installer.iss
+++ b/installer/arm64/installer.iss
@@ -22,6 +22,10 @@ OutputDir=userdocs:ProfileExplorer
 ChangesAssociations = yes
 ChangesEnvironment = yes
 OutputBaseFilename=profile_explorer_installer_{#APP_VERSION}_arm64
+; Run installer in 64-bit (ARM64) mode so {sys} resolves to System32 and the
+; correct architecture regsvr32.exe registers msdia140.dll.
+ArchitecturesAllowed=arm64
+ArchitecturesInstallIn64BitMode=arm64
 
 [Registry]
 Root: HKCR; Subkey: "{#MyAppName}";                     ValueData: "Program {#MyAppName}";  Flags: uninsdeletekey;   ValueType: string;  ValueName: ""
@@ -38,7 +42,10 @@ Name: "{group}\Profile Explorer"; Filename: "{app}\ProfileExplorer.exe"
 Name: envPath; Description: "Add to PATH env. variable as ProfileExplorer.exe" 
 
 [Run]
-Filename: "{sys}\Regsvr32.exe"; Parameters: "/s msdia140.dll"; WorkingDir: "{app}"; Flags: shellexec runhidden; 
+Filename: "{sys}\Regsvr32.exe"; Parameters: "/s ""{app}\msdia140.dll"""; WorkingDir: "{app}"; Flags: runhidden;
+
+[UninstallRun]
+Filename: "{sys}\Regsvr32.exe"; Parameters: "/s /u ""{app}\msdia140.dll"""; Flags: runhidden;
 
 [Code]
 procedure CurStepChanged(CurStep: TSetupStep);

--- a/installer/x64/installer.iss
+++ b/installer/x64/installer.iss
@@ -22,6 +22,11 @@ OutputDir=userdocs:ProfileExplorer
 ChangesAssociations = yes
 ChangesEnvironment = yes
 OutputBaseFilename=profile_explorer_installer_{#APP_VERSION}_x64
+; Run installer in 64-bit mode so {sys} resolves to System32 (64-bit regsvr32.exe).
+; Without this flag, {sys} = SysWOW64 and 32-bit regsvr32 fails to register
+; the 64-bit msdia140.dll silently (because of /s), breaking PDB loading.
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
 
 [Registry]
 Root: HKCR; Subkey: "{#MyAppName}";                     ValueData: "Program {#MyAppName}";  Flags: uninsdeletekey;   ValueType: string;  ValueName: ""
@@ -38,7 +43,10 @@ Name: "{group}\Profile Explorer"; Filename: "{app}\ProfileExplorer.exe"
 Name: envPath; Description: "Add to PATH env. variable as ProfileExplorer.exe" 
 
 [Run]
-Filename: "{sys}\Regsvr32.exe"; Parameters: "/s msdia140.dll"; WorkingDir: "{app}"; Flags: shellexec runhidden; 
+Filename: "{sys}\Regsvr32.exe"; Parameters: "/s ""{app}\msdia140.dll"""; WorkingDir: "{app}"; Flags: runhidden;
+
+[UninstallRun]
+Filename: "{sys}\Regsvr32.exe"; Parameters: "/s /u ""{app}\msdia140.dll"""; Flags: runhidden;
 
 [Code]
 procedure CurStepChanged(CurStep: TSetupStep);

--- a/src/ProfileExplorerUI/ProfileExplorerUI.csproj
+++ b/src/ProfileExplorerUI/ProfileExplorerUI.csproj
@@ -338,5 +338,84 @@
 		</Content>
 	</ItemGroup>
 
+	<!-- Copy capstone.dll to output root for disassembler P/Invoke (built by src/external/build-capstone.cmd) -->
+	<ItemGroup Condition="'$(Platform)' == 'ARM64' And Exists('..\external\capstone\build_arm64\Release\capstone.dll')">
+		<Content Include="..\external\capstone\build_arm64\Release\capstone.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Link>capstone.dll</Link>
+		</Content>
+	</ItemGroup>
+	<ItemGroup Condition="'$(Platform)' != 'ARM64' And Exists('..\external\capstone\build\Release\capstone.dll')">
+		<Content Include="..\external\capstone\build\Release\capstone.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Link>capstone.dll</Link>
+		</Content>
+	</ItemGroup>
+
+	<Target Name="WarnIfCapstoneMissing" BeforeTargets="Build"
+	        Condition="'$(Platform)' != 'ARM64' And !Exists('..\external\capstone\build\Release\capstone.dll')">
+		<Warning Text="capstone.dll not found at ..\external\capstone\build\Release\capstone.dll. Run src\external\build-capstone.cmd to build it; otherwise disassembly will fail at runtime." />
+	</Target>
+
+	<!-- Copy Graphviz dot.exe and its DLLs to output root for graph rendering (built by src/external/build-graphviz.cmd) -->
+	<ItemGroup Condition="'$(Platform)' != 'ARM64' And Exists('..\external\graphviz\build\cmd\dot\Release\dot.exe')">
+		<Content Include="..\external\graphviz\build\cmd\dot\Release\dot.exe">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Link>dot.exe</Link>
+		</Content>
+		<Content Include="..\external\graphviz\build\lib\cdt\Release\cdt.dll" Condition="Exists('..\external\graphviz\build\lib\cdt\Release\cdt.dll')">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Link>cdt.dll</Link>
+		</Content>
+		<Content Include="..\external\graphviz\build\lib\cgraph\Release\cgraph.dll" Condition="Exists('..\external\graphviz\build\lib\cgraph\Release\cgraph.dll')">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Link>cgraph.dll</Link>
+		</Content>
+		<Content Include="..\external\graphviz\build\lib\gvc\Release\gvc.dll" Condition="Exists('..\external\graphviz\build\lib\gvc\Release\gvc.dll')">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Link>gvc.dll</Link>
+		</Content>
+		<Content Include="..\external\graphviz\build\lib\pathplan\Release\pathplan.dll" Condition="Exists('..\external\graphviz\build\lib\pathplan\Release\pathplan.dll')">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Link>pathplan.dll</Link>
+		</Content>
+		<Content Include="..\external\graphviz\build\lib\xdot\Release\xdot.dll" Condition="Exists('..\external\graphviz\build\lib\xdot\Release\xdot.dll')">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Link>xdot.dll</Link>
+		</Content>
+		<Content Include="..\external\graphviz\build\plugin\core\Release\gvplugin_core.dll" Condition="Exists('..\external\graphviz\build\plugin\core\Release\gvplugin_core.dll')">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Link>gvplugin_core.dll</Link>
+		</Content>
+		<Content Include="..\external\graphviz\build\plugin\dot_layout\Release\gvplugin_dot_layout.dll" Condition="Exists('..\external\graphviz\build\plugin\dot_layout\Release\gvplugin_dot_layout.dll')">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Link>gvplugin_dot_layout.dll</Link>
+		</Content>
+		<Content Include="..\external\graphviz\windows\dependencies\libraries\vcpkg\installed\x64-windows\bin\zlib1.dll" Condition="Exists('..\external\graphviz\windows\dependencies\libraries\vcpkg\installed\x64-windows\bin\zlib1.dll')">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Link>zlib1.dll</Link>
+		</Content>
+		<Content Include="..\external\graphviz\windows\dependencies\libraries\vcpkg\installed\x64-windows\bin\libexpat.dll" Condition="Exists('..\external\graphviz\windows\dependencies\libraries\vcpkg\installed\x64-windows\bin\libexpat.dll')">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Link>libexpat.dll</Link>
+		</Content>
+	</ItemGroup>
+
+	<!-- Copy tree-sitter parser DLLs for source-code parsing P/Invoke (built by src/external/build-tree-sitter.cmd via nmake) -->
+	<ItemGroup Condition="'$(Platform)' != 'ARM64' And Exists('..\external\tree-sitter\build')">
+		<Content Include="..\external\tree-sitter\build\*.dll">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
+
+	<Target Name="WarnIfGraphvizMissing" BeforeTargets="Build"
+	        Condition="'$(Platform)' != 'ARM64' And !Exists('..\external\graphviz\build\cmd\dot\Release\dot.exe')">
+		<Warning Text="dot.exe not found at ..\external\graphviz\build\cmd\dot\Release\dot.exe. Run src\external\build-graphviz.cmd to build it; otherwise flow/expression/call graph rendering will fail." />
+	</Target>
+
+	<Target Name="WarnIfTreeSitterMissing" BeforeTargets="Build"
+	        Condition="'$(Platform)' != 'ARM64' And !Exists('..\external\tree-sitter\build')">
+		<Warning Text="tree-sitter DLLs not found at ..\external\tree-sitter\build\. Run src\external\build-tree-sitter.cmd (requires nmake from a VS dev prompt); otherwise source-code parsing will fail." />
+	</Target>
 
 </Project>


### PR DESCRIPTION
  Two related build/install issues that broke local builds and installer
  runs in non-obvious ways:

  1. `dotnet build` did not copy capstone.dll, the graphviz binaries (dot.exe + 9 DLLs), or the tree-sitter DLLs from src/external into the bin output — only the installer's prepare-out.cmd staged them. So running ProfileExplorer.exe directly from bin\Release crashed on first disassembly with DllNotFoundException for capstone.dll, and graph rendering / source-code parsing silently failed. Added Content items in ProfileExplorerUI.csproj that copy each native dep into the bin output, guarded with Exists() so a fresh clone (where build-capstone.cmd / build-graphviz.cmd / build-tree-sitter.cmd haven't run yet) still builds — with a warning instead of an error.

  2. The Inno Setup installer was missing ArchitecturesInstallIn64BitMode, so it ran in 32-bit mode. {sys} resolved to SysWOW64, and the post-install regsvr32 invoked the 32-bit regsvr32.exe to register the 64-bit msdia140.dll. The /s flag silently swallowed the failure, leaving msdia140 unregistered and PDBDebugInfoProvider throwing class-factory errors at runtime. Set ArchitecturesAllowed
     + ArchitecturesInstallIn64BitMode for both x64 and arm64 installers, used a fully-qualified {app} path for the DLL, and added an [UninstallRun] entry to unregister on uninstall.