### PR TITLE
Fix SFI CFSClean2 violation: use GitHub mirror for graphviz submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/capstone-engine/capstone.git
 [submodule "src/external/graphviz"]
 	path = src/external/graphviz
-	url = https://gitlab.com/graphviz/graphviz.git
+	url = https://github.com/bgn64/graphviz.git
 [submodule "src/external/tree-sitter/csharp-tree-sitter"]
 	path = src/external/tree-sitter/csharp-tree-sitter
 	url = https://github.com/bgn64/csharp-tree-sitter.git


### PR DESCRIPTION
The OneBranch pipeline network isolation CFSClean2 policy flags connections to gitlab.com as a policy violation. The graphviz submodule and its two nested submodules all referenced gitlab.com, causing CFSClean2 violations during recursive submodule checkout.

Mirrored all three repos to GitHub and updated submodule URLs:
- graphviz -> https://github.com/bgn64/graphviz
- graphviz-build-utilities -> https://github.com/bgn64/graphviz-build-utilities
- graphviz-windows-dependencies -> https://github.com/bgn64/graphviz-windows-dependencies

This follows the same pattern used for csharp-tree-sitter (bgn64/csharp-tree-sitter).