### PR TITLE
Add MCP close_trace tool, strict open_trace, and --mcp lazy-window mode

### DIFF
--- a/src/ProfileExplorer.Mcp/IMcpActionExecutor.cs
+++ b/src/ProfileExplorer.Mcp/IMcpActionExecutor.cs
@@ -58,6 +58,14 @@ public interface IMcpActionExecutor
     /// <param name="topCount">Optional number to limit results to the top N binaries by performance (e.g., 10 for top 10 most time-consuming binaries)</param>
     /// <returns>Task that completes with the list of available binaries in the currently loaded process</returns>
     Task<GetAvailableBinariesResult> GetAvailableBinariesAsync(double? minTimePercentage = null, TimeSpan? minTime = null, int? topCount = null);
+
+    /// <summary>
+    /// Closes the currently loaded trace/profile session and releases its resources.
+    /// Idempotent: returns Success=true with WasLoaded=false when no profile session is loaded.
+    /// Only closes profile sessions; non-profile sessions (e.g. IR documents) are left untouched.
+    /// </summary>
+    /// <returns>Task that completes with details about what was closed</returns>
+    Task<CloseTraceResult> CloseTraceAsync();
 }
 
 /// <summary>
@@ -126,6 +134,49 @@ public enum OpenTraceFailureReason
     TraceLoadTimeout,
     ProcessListLoadTimeout,
     ProfileLoadTimeout,
+    UIError,
+    UnknownError,
+    TraceAlreadyLoaded
+}
+
+/// <summary>
+/// Result of a CloseTrace operation. Idempotent — Success=true with WasLoaded=false
+/// is the expected response when no trace was loaded at the time of the call.
+/// </summary>
+public class CloseTraceResult
+{
+    public bool Success { get; set; }
+    public CloseTraceFailureReason FailureReason { get; set; } = CloseTraceFailureReason.None;
+    public string? ErrorMessage { get; set; }
+
+    /// <summary>
+    /// True if a profile session was actually loaded and closed by this call.
+    /// False (with Success=true) when no profile was loaded — the call is a no-op.
+    /// </summary>
+    public bool WasLoaded { get; set; }
+
+    /// <summary>
+    /// Path of the trace that was closed, if any.
+    /// </summary>
+    public string? ClosedProfilePath { get; set; }
+
+    /// <summary>
+    /// Process id that was loaded in the closed trace, if known.
+    /// </summary>
+    public int? ClosedProcessId { get; set; }
+
+    /// <summary>
+    /// Friendly name of the process that was loaded in the closed trace, if known.
+    /// </summary>
+    public string? ClosedProcessName { get; set; }
+}
+
+/// <summary>
+/// Specific reasons why a CloseTrace operation might fail.
+/// </summary>
+public enum CloseTraceFailureReason
+{
+    None,
     UIError,
     UnknownError
 }

--- a/src/ProfileExplorer.Mcp/ProfileExplorerMcpServer.cs
+++ b/src/ProfileExplorer.Mcp/ProfileExplorerMcpServer.cs
@@ -59,7 +59,7 @@ public static class ProfileExplorerTools
 
     #region Simplified MCP Tool
 
-    [McpServerTool, Description("Open and load a trace file with a specific process by name or ID in one complete operation")]
+    [McpServerTool, Description("Open and load a trace file with a specific process by name or ID. Precondition: no trace may be loaded; call close_trace first if one is. Returns Failed/TraceAlreadyLoaded otherwise.")]
     public static async Task<string> OpenTrace(string profileFilePath, string processNameOrId)
     {
         if (string.IsNullOrWhiteSpace(profileFilePath))
@@ -73,6 +73,22 @@ public static class ProfileExplorerTools
             if (_executor == null)
             {
                 throw new InvalidOperationException("MCP action executor is not initialized");
+            }
+
+            // Strict precondition: a profile must not already be loaded. Enforce here
+            // (before the process-list preflight below) so ambiguous-process responses
+            // don't bypass the check.
+            var status = await _executor.GetStatusAsync();
+            if (status.IsProfileLoaded)
+            {
+                return SerializeOpenTraceResult(new OpenTraceResult
+                {
+                    Success = false,
+                    FailureReason = OpenTraceFailureReason.TraceAlreadyLoaded,
+                    ErrorMessage = $"A trace is already loaded ('{status.CurrentProfilePath}'" +
+                                   (status.CurrentProcess != null ? $", PID {status.CurrentProcess.ProcessId}" : "") +
+                                   "). Call close_trace before open_trace."
+                }, profileFilePath, processNameOrId);
             }
 
             // First, check if this might be an ambiguous query by getting available processes
@@ -648,6 +664,60 @@ public static class ProfileExplorerTools
         }
     }
 
+    [McpServerTool, Description("Close the currently loaded trace and release its resources. Use between iterations when capturing fresh traces (build → capture → close_trace → open_trace → analyze). Idempotent: succeeds with WasLoaded=false when no trace is loaded. Only closes profile/trace sessions; non-profile sessions are left untouched.")]
+    public static async Task<string> CloseTrace()
+    {
+        try
+        {
+            if (_executor == null)
+            {
+                throw new InvalidOperationException("MCP action executor is not initialized");
+            }
+
+            var result = await _executor.CloseTraceAsync();
+
+            if (!result.Success)
+            {
+                var errorResult = new
+                {
+                    Action = "CloseTrace",
+                    Status = "Failed",
+                    FailureReason = result.FailureReason.ToString(),
+                    Description = result.ErrorMessage ?? "Unknown error closing trace",
+                    Timestamp = DateTime.UtcNow
+                };
+                return System.Text.Json.JsonSerializer.Serialize(errorResult, new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+            }
+
+            var successResult = new
+            {
+                Action = "CloseTrace",
+                Status = "Success",
+                WasLoaded = result.WasLoaded,
+                ClosedProfilePath = result.ClosedProfilePath,
+                ClosedProcessId = result.ClosedProcessId,
+                ClosedProcessName = result.ClosedProcessName,
+                Description = result.WasLoaded
+                    ? $"Closed trace '{result.ClosedProfilePath}' (PID: {result.ClosedProcessId})"
+                    : "No trace was loaded; close was a no-op",
+                Timestamp = DateTime.UtcNow
+            };
+            return System.Text.Json.JsonSerializer.Serialize(successResult, new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+        }
+        catch (Exception ex)
+        {
+            var errorResult = new
+            {
+                Action = "CloseTrace",
+                Status = "Error",
+                Error = ex.Message,
+                Timestamp = DateTime.UtcNow
+            };
+
+            return System.Text.Json.JsonSerializer.Serialize(errorResult, new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+        }
+    }
+
     #endregion
 
     #region Help Tool
@@ -693,6 +763,11 @@ public static class ProfileExplorerTools
                     Name = "GetFunctionAssembly", 
                     Description = "Get assembly code for a specific function by double-clicking on it in the Summary pane, and save it to a file for later contextual reference by Copilot",
                     Parameters = "functionName (string) - Name of the function to retrieve assembly for (supports partial matching)"
+                },
+                new {
+                    Name = "CloseTrace",
+                    Description = "Close the currently loaded trace and release its resources. Use between iterations when capturing fresh traces. Idempotent: succeeds even if no trace is loaded.",
+                    Parameters = "none"
                 },
                 new { 
                     Name = "GetHelp", 

--- a/src/ProfileExplorer.Mcp/ProfileExplorerMcpServer.cs
+++ b/src/ProfileExplorer.Mcp/ProfileExplorerMcpServer.cs
@@ -75,20 +75,15 @@ public static class ProfileExplorerTools
                 throw new InvalidOperationException("MCP action executor is not initialized");
             }
 
-            // Strict precondition: a profile must not already be loaded. Enforce here
-            // (before the process-list preflight below) so ambiguous-process responses
-            // don't bypass the check.
+            // If a profile is loaded, route directly to OpenTraceAsync so it can either
+            // succeed idempotently (same trace+process) or fail with TraceAlreadyLoaded
+            // (different trace). Skipping the ambiguity preflight ensures the agent gets
+            // a clear answer instead of a process list.
             var status = await _executor.GetStatusAsync();
             if (status.IsProfileLoaded)
             {
-                return SerializeOpenTraceResult(new OpenTraceResult
-                {
-                    Success = false,
-                    FailureReason = OpenTraceFailureReason.TraceAlreadyLoaded,
-                    ErrorMessage = $"A trace is already loaded ('{status.CurrentProfilePath}'" +
-                                   (status.CurrentProcess != null ? $", PID {status.CurrentProcess.ProcessId}" : "") +
-                                   "). Call close_trace before open_trace."
-                }, profileFilePath, processNameOrId);
+                OpenTraceResult preconditionResult = await _executor.OpenTraceAsync(profileFilePath, processNameOrId);
+                return SerializeOpenTraceResult(preconditionResult, profileFilePath, processNameOrId);
             }
 
             // First, check if this might be an ambiguous query by getting available processes

--- a/src/ProfileExplorer.Mcp/Program.cs
+++ b/src/ProfileExplorer.Mcp/Program.cs
@@ -428,4 +428,14 @@ ret";
             Binaries = filteredBinaries
         });
     }
+
+    public Task<CloseTraceResult> CloseTraceAsync()
+    {
+        Console.WriteLine("Mock: CloseTraceAsync called");
+        return Task.FromResult(new CloseTraceResult
+        {
+            Success = true,
+            WasLoaded = false
+        });
+    }
 }

--- a/src/ProfileExplorerUI/App.xaml.cs
+++ b/src/ProfileExplorerUI/App.xaml.cs
@@ -87,6 +87,11 @@ public partial class App : Application {
   /// When true, suppresses UI dialogs (like source file prompts) during MCP/automation operations.
   /// </summary>
   public static bool SuppressDialogsForAutomation;
+  /// <summary>
+  /// True when launched with --mcp: skip showing the MainWindow at startup
+  /// (lazily shown on first MCP tool call that needs the UI).
+  /// </summary>
+  public static bool IsMcpMode;
   private Task? mcpServerTask;
   private static List<SyntaxFileInfo> cachedSyntaxHighlightingFiles_;
   public static string ApplicationPath => Process.GetCurrentProcess().MainModule?.FileName;
@@ -626,7 +631,15 @@ public partial class App : Application {
 
     // Create and show the main window manually
     var mainWindow = new MainWindow();
-    mainWindow.Show();
+    IsMcpMode = Array.Exists(e.Args, a => string.Equals(a, "--mcp", StringComparison.OrdinalIgnoreCase));
+    if (IsMcpMode) {
+      // Stay alive without a visible window until MCP shuts us down or a tool shows the window.
+      ShutdownMode = ShutdownMode.OnExplicitShutdown;
+      SuppressDialogsForAutomation = true;
+    }
+    else {
+      mainWindow.Show();
+    }
 
     // Initialize MCP server if enabled
     InitializeMcpServerAsync(mainWindow);

--- a/src/ProfileExplorerUI/App.xaml.cs
+++ b/src/ProfileExplorerUI/App.xaml.cs
@@ -636,13 +636,11 @@ public partial class App : Application {
       // Stay alive without a visible window until MCP shuts us down or a tool shows the window.
       ShutdownMode = ShutdownMode.OnExplicitShutdown;
       SuppressDialogsForAutomation = true;
+      InitializeMcpServerAsync(mainWindow);
     }
     else {
       mainWindow.Show();
     }
-
-    // Initialize MCP server if enabled
-    InitializeMcpServerAsync(mainWindow);
   }
 
   private void InitializeMcpServerAsync(MainWindow mainWindow)

--- a/src/ProfileExplorerUI/App.xaml.cs
+++ b/src/ProfileExplorerUI/App.xaml.cs
@@ -595,6 +595,9 @@ public partial class App : Application {
     AppStartTime = DateTime.UtcNow;
     base.OnStartup(e);
 
+    IsMcpMode = Array.Exists(e.Args, a => string.Equals(a, "--mcp", StringComparison.OrdinalIgnoreCase));
+    SuppressDialogsForAutomation = IsMcpMode;
+
     // Initialize UI-specific JSON converters
     UIJsonUtils.Initialize();
 
@@ -602,7 +605,7 @@ public partial class App : Application {
     RegisterSettingsTypeConverters();
 
     if (!Debugger.IsAttached) {
-      SetupExceptionHandling();
+      SetupExceptionHandling(showUIPrompt: !IsMcpMode);
     }
 
     FixPopupPlacement();
@@ -631,11 +634,9 @@ public partial class App : Application {
 
     // Create and show the main window manually
     var mainWindow = new MainWindow();
-    IsMcpMode = Array.Exists(e.Args, a => string.Equals(a, "--mcp", StringComparison.OrdinalIgnoreCase));
     if (IsMcpMode) {
       // Stay alive without a visible window until MCP shuts us down or a tool shows the window.
       ShutdownMode = ShutdownMode.OnExplicitShutdown;
-      SuppressDialogsForAutomation = true;
       InitializeMcpServerAsync(mainWindow);
     }
     else {

--- a/src/ProfileExplorerUI/MainWindow.xaml.cs
+++ b/src/ProfileExplorerUI/MainWindow.xaml.cs
@@ -99,6 +99,8 @@ public partial class MainWindow : Window, IUISession, INotifyPropertyChanged {
   private DocumentSearchPanel documentSearchPanel_;
   private bool initialDockLayoutRestored_;
   private bool profileControlsVisible;
+  private readonly TaskCompletionSource<bool> initialLoadCompleted_ =
+    new(TaskCreationOptions.RunContinuationsAsynchronously);
 
   public MainWindow() {
     InitializeComponent();
@@ -127,6 +129,7 @@ public partial class MainWindow : Window, IUISession, INotifyPropertyChanged {
 
   public event PropertyChangedEventHandler PropertyChanged;
   public SessionStateManager SessionState => sessionState_;
+  public Task InitialLoadCompleted => initialLoadCompleted_.Task;
 
   public IRTextSummary GetDocumentSummary(IRTextSection section) {
     return sessionState_.FindLoadedDocument(section).Summary;
@@ -579,36 +582,50 @@ public partial class MainWindow : Window, IUISession, INotifyPropertyChanged {
   }
 
   private async void Window_Loaded(object sender, RoutedEventArgs e) {
-    await SetupCompilerTarget();
-    SectionPanel.OpenSection += SectionPanel_OpenSection;
-    SectionPanel.EnterDiffMode += SectionPanel_EnterDiffMode;
-    SectionPanel.SyncDiffedDocumentsChanged += SectionPanel_SyncDiffedDocumentsChanged;
-    SectionPanel.DisplayCallGraph += SectionPanel_DisplayCallGraph;
-    SearchResultsPanel.OpenSection += SectionPanel_OpenSection;
+    try {
+      if (compilerInfo_ == null) {
+        await SetupCompilerTarget();
+      }
+      else {
+        SetupMainWindowCompilerTarget();
+      }
 
-    if (!RestoreDockLayout()) {
-      RegisterDefaultToolPanels();
+      SectionPanel.OpenSection += SectionPanel_OpenSection;
+      SectionPanel.EnterDiffMode += SectionPanel_EnterDiffMode;
+      SectionPanel.SyncDiffedDocumentsChanged += SectionPanel_SyncDiffedDocumentsChanged;
+      SectionPanel.DisplayCallGraph += SectionPanel_DisplayCallGraph;
+      SearchResultsPanel.OpenSection += SectionPanel_OpenSection;
+
+      if (!RestoreDockLayout()) {
+        RegisterDefaultToolPanels();
+      }
+
+      ResetStatusBar();
+
+      // Make help panel active on the first run.
+      if (App.IsFirstRun) {
+        await ShowPanel(ToolPanelKind.Help);
+      }
+
+      await ProcessStartupArgs();
+
+      if (!IsSessionStarted) {
+        UpdatePanelEnabledState(false);
+      }
+      else {
+        // Hide the start page if a file was loaded on start.
+        HideStartPage();
+      }
+
+      if (App.Settings.GeneralSettings.CheckForUpdates) {
+        StartApplicationUpdateTimer();
+      }
+
+      initialLoadCompleted_.TrySetResult(true);
     }
-
-    ResetStatusBar();
-
-    // Make help panel active on the first run.
-    if (App.IsFirstRun) {
-      await ShowPanel(ToolPanelKind.Help);
-    }
-
-    await ProcessStartupArgs();
-
-    if (!IsSessionStarted) {
-      UpdatePanelEnabledState(false);
-    }
-    else {
-      // Hide the start page if a file was loaded on start.
-      HideStartPage();
-    }
-
-    if (App.Settings.GeneralSettings.CheckForUpdates) {
-      StartApplicationUpdateTimer();
+    catch (Exception ex) {
+      initialLoadCompleted_.TrySetException(ex);
+      throw;
     }
   }
 

--- a/src/ProfileExplorerUI/MainWindowProfiling.cs
+++ b/src/ProfileExplorerUI/MainWindowProfiling.cs
@@ -503,7 +503,10 @@ public partial class MainWindow : Window, IUISession {
 
   private async Task LoadProfile() {
     var window = new ProfileLoadWindow(this, false);
-    window.Owner = this;
+    if (IsVisible) {
+      window.Owner = this;
+    }
+
     bool? result = window.ShowDialog();
 
     if (result.HasValue && result.Value) {

--- a/src/ProfileExplorerUI/MainWindowSession.cs
+++ b/src/ProfileExplorerUI/MainWindowSession.cs
@@ -709,6 +709,14 @@ public partial class MainWindow : Window, IUISession {
     HideStartPage();
   }
 
+  /// <summary>
+  /// Public wrapper around <see cref="EndSession"/> for callers outside MainWindow
+  /// (in particular the MCP layer).
+  /// </summary>
+  public Task CloseSessionAsync(bool showStartPage = true) {
+    return EndSession(showStartPage);
+  }
+
   private async Task EndSession(bool showStartPage = true) {
     await BeginSessionStateChange();
 

--- a/src/ProfileExplorerUI/Mcp/McpActionExecutor.cs
+++ b/src/ProfileExplorerUI/Mcp/McpActionExecutor.cs
@@ -47,9 +47,16 @@ public class McpActionExecutor : IMcpActionExecutor
             };
         }
 
-        // Strict precondition: a profile must not already be loaded. Caller is
-        // expected to invoke close_trace first. This also avoids the silent
-        // no-op from LoadProfile.CanExecute (MainWindowProfiling.cs:577 —
+        // Idempotent: if the same trace+process is already loaded, succeed without reloading.
+        var alreadyLoadedResult = await CheckIfTraceAlreadyLoadedAsync(profileFilePath, processIdentifier);
+        if (alreadyLoadedResult != null)
+        {
+            return alreadyLoadedResult;
+        }
+
+        // Strict precondition: a different profile must not already be loaded.
+        // Caller must call close_trace first. This also avoids the silent no-op
+        // from LoadProfile.CanExecute (MainWindowProfiling.cs:577 —
         // !IsSessionStarted || ProfileData == null) when a profile is loaded.
         var existingProfile = await GetLoadedProfileSummaryAsync();
         if (existingProfile != null)
@@ -58,21 +65,12 @@ public class McpActionExecutor : IMcpActionExecutor
             {
                 Success = false,
                 FailureReason = OpenTraceFailureReason.TraceAlreadyLoaded,
-                ErrorMessage = $"A trace is already loaded ('{existingProfile.Value.tracePath}', " +
+                ErrorMessage = $"A different trace is already loaded ('{existingProfile.Value.tracePath}', " +
                                $"PID {existingProfile.Value.processId}). Call close_trace before open_trace."
             };
         }
 
-        // In --mcp mode the MainWindow was created hidden; show it now that we're
-        // about to load and display a trace.
-        await dispatcher.InvokeAsync(() =>
-        {
-            if (!mainWindow.IsVisible)
-            {
-                mainWindow.Show();
-            }
-        });
-
+        OpenTraceResult result;
         if (int.TryParse(processIdentifier, out int processId))
         {
             if (processId <= 0)
@@ -84,11 +82,27 @@ public class McpActionExecutor : IMcpActionExecutor
                     ErrorMessage = "Process ID must be a positive integer."
                 };
             }
-            return await OpenTraceByProcessIdAsync(profileFilePath, processId);
+            result = await OpenTraceByProcessIdAsync(profileFilePath, processId);
+        }
+        else
+        {
+            // If not a number, treat as process name
+            result = await OpenTraceByProcessNameAsync(profileFilePath, processIdentifier);
         }
 
-        // If not a number, treat as process name
-        return await OpenTraceByProcessNameAsync(profileFilePath, processIdentifier);
+        // In --mcp mode MainWindow is hidden; show it only on a successful load,
+        // not earlier — a late load failure should not leave a window behind.
+        if (result.Success)
+        {
+            await dispatcher.InvokeAsync(() =>
+            {
+                if (!mainWindow.IsVisible)
+                {
+                    mainWindow.Show();
+                }
+            });
+        }
+        return result;
     }
 
     /// <summary>

--- a/src/ProfileExplorerUI/Mcp/McpActionExecutor.cs
+++ b/src/ProfileExplorerUI/Mcp/McpActionExecutor.cs
@@ -70,7 +70,17 @@ public class McpActionExecutor : IMcpActionExecutor
             };
         }
 
-        OpenTraceResult result;
+        // In --mcp mode the MainWindow was created hidden; show it now that we're
+        // about to load a trace. WPF requires Owner to have been Show()n before
+        // ProfileLoadWindow.Owner can be set during the load.
+        dispatcher.Invoke(() =>
+        {
+            if (!mainWindow.IsVisible)
+            {
+                mainWindow.Show();
+            }
+        });
+
         if (int.TryParse(processIdentifier, out int processId))
         {
             if (processId <= 0)
@@ -82,27 +92,11 @@ public class McpActionExecutor : IMcpActionExecutor
                     ErrorMessage = "Process ID must be a positive integer."
                 };
             }
-            result = await OpenTraceByProcessIdAsync(profileFilePath, processId);
-        }
-        else
-        {
-            // If not a number, treat as process name
-            result = await OpenTraceByProcessNameAsync(profileFilePath, processIdentifier);
+            return await OpenTraceByProcessIdAsync(profileFilePath, processId);
         }
 
-        // In --mcp mode MainWindow is hidden; show it only on a successful load,
-        // not earlier — a late load failure should not leave a window behind.
-        if (result.Success)
-        {
-            await dispatcher.InvokeAsync(() =>
-            {
-                if (!mainWindow.IsVisible)
-                {
-                    mainWindow.Show();
-                }
-            });
-        }
-        return result;
+        // If not a number, treat as process name
+        return await OpenTraceByProcessNameAsync(profileFilePath, processIdentifier);
     }
 
     /// <summary>

--- a/src/ProfileExplorerUI/Mcp/McpActionExecutor.cs
+++ b/src/ProfileExplorerUI/Mcp/McpActionExecutor.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
@@ -2053,7 +2052,7 @@ public class McpActionExecutor : IMcpActionExecutor
     /// Returns identifying details of the currently loaded profile session, or null when
     /// no profile is loaded. Reads via the dispatcher because it touches MainWindow state.
     /// </summary>
-    private async Task<(string? tracePath, int? processId, string? processName)?> GetLoadedProfileSummaryAsync()
+    private async Task<(string tracePath, int? processId, string processName)?> GetLoadedProfileSummaryAsync()
     {
         return await dispatcher.InvokeAsync(() =>
         {
@@ -2063,12 +2062,12 @@ public class McpActionExecutor : IMcpActionExecutor
 
             if (report == null)
             {
-                return ((string? tracePath, int? processId, string? processName)?)null;
+                return ((string tracePath, int? processId, string processName)?)null;
             }
 
-            string? tracePath = report.TraceInfo?.TraceFilePath;
+            string tracePath = report.TraceInfo?.TraceFilePath;
             int? processId = report.Process?.ProcessId;
-            string? processName = report.Process?.Name;
+            string processName = report.Process?.Name;
             return (tracePath, processId, processName);
         });
     }

--- a/src/ProfileExplorerUI/Mcp/McpActionExecutor.cs
+++ b/src/ProfileExplorerUI/Mcp/McpActionExecutor.cs
@@ -47,10 +47,21 @@ public class McpActionExecutor : IMcpActionExecutor
             };
         }
 
+        if (string.IsNullOrWhiteSpace(processIdentifier))
+        {
+            return new OpenTraceResult
+            {
+                Success = false,
+                FailureReason = OpenTraceFailureReason.UnknownError,
+                ErrorMessage = "Process identifier must be a process ID or process name."
+            };
+        }
+
         // Idempotent: if the same trace+process is already loaded, succeed without reloading.
         var alreadyLoadedResult = await CheckIfTraceAlreadyLoadedAsync(profileFilePath, processIdentifier);
         if (alreadyLoadedResult != null)
         {
+            await EnsureMainWindowReadyAsync();
             return alreadyLoadedResult;
         }
 
@@ -61,25 +72,19 @@ public class McpActionExecutor : IMcpActionExecutor
         var existingProfile = await GetLoadedProfileSummaryAsync();
         if (existingProfile != null)
         {
+            string errorMessage = IsSameTraceFile(profileFilePath, existingProfile.Value.tracePath)
+                ? $"Trace '{existingProfile.Value.tracePath}' is already loaded with a different process " +
+                  $"(PID {existingProfile.Value.processId}). Call close_trace before open_trace to switch processes."
+                : $"A different trace is already loaded ('{existingProfile.Value.tracePath}', " +
+                  $"PID {existingProfile.Value.processId}). Call close_trace before open_trace.";
+
             return new OpenTraceResult
             {
                 Success = false,
                 FailureReason = OpenTraceFailureReason.TraceAlreadyLoaded,
-                ErrorMessage = $"A different trace is already loaded ('{existingProfile.Value.tracePath}', " +
-                               $"PID {existingProfile.Value.processId}). Call close_trace before open_trace."
+                ErrorMessage = errorMessage
             };
         }
-
-        // In --mcp mode the MainWindow was created hidden; show it now that we're
-        // about to load a trace. WPF requires Owner to have been Show()n before
-        // ProfileLoadWindow.Owner can be set during the load.
-        dispatcher.Invoke(() =>
-        {
-            if (!mainWindow.IsVisible)
-            {
-                mainWindow.Show();
-            }
-        });
 
         if (int.TryParse(processIdentifier, out int processId))
         {
@@ -92,11 +97,46 @@ public class McpActionExecutor : IMcpActionExecutor
                     ErrorMessage = "Process ID must be a positive integer."
                 };
             }
+
             return await OpenTraceByProcessIdAsync(profileFilePath, processId);
         }
 
         // If not a number, treat as process name
         return await OpenTraceByProcessNameAsync(profileFilePath, processIdentifier);
+    }
+
+    private async Task EnsureMainWindowReadyAsync()
+    {
+        await dispatcher.InvokeAsync(() =>
+        {
+            if (!mainWindow.IsVisible)
+            {
+                mainWindow.Show();
+            }
+        });
+
+        await mainWindow.InitialLoadCompleted;
+    }
+
+    private static bool IsSameTraceFile(string requestedPath, string loadedPath)
+    {
+        if (string.IsNullOrEmpty(requestedPath) || string.IsNullOrEmpty(loadedPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            return string.Equals(Path.GetFullPath(requestedPath),
+                                 Path.GetFullPath(loadedPath),
+                                 StringComparison.OrdinalIgnoreCase);
+        }
+        catch (Exception ex) when (ex is ArgumentException ||
+                                   ex is NotSupportedException ||
+                                   ex is PathTooLongException)
+        {
+            return string.Equals(requestedPath, loadedPath, StringComparison.OrdinalIgnoreCase);
+        }
     }
 
     /// <summary>
@@ -185,11 +225,17 @@ public class McpActionExecutor : IMcpActionExecutor
         {
             var loadResult = await LoadTraceAsync(profileFilePath);
             if (!loadResult.Success) {
+                await CloseProfileLoadWindowAsync(loadResult.ProfileLoadWindow);
                 return loadResult.Result;
             }
             
             // Select the process by PID
-            return await SelectProcessByPidAsync(loadResult.ProfileLoadWindow, processId);
+            var result = await SelectProcessByPidAsync(loadResult.ProfileLoadWindow, processId);
+            if (!result.Success) {
+                await CloseProfileLoadWindowAsync(loadResult.ProfileLoadWindow);
+            }
+
+            return result;
         }
         catch (Exception ex)
         {
@@ -207,11 +253,17 @@ public class McpActionExecutor : IMcpActionExecutor
             // Load the trace and prepare the process list
             var loadResult = await LoadTraceAsync(profileFilePath);
             if (!loadResult.Success) {
+                await CloseProfileLoadWindowAsync(loadResult.ProfileLoadWindow);
                 return loadResult.Result;
             }
 
             // Select the process by name
-            return await SelectProcessByNameAsync(loadResult.ProfileLoadWindow, processName);
+            var result = await SelectProcessByNameAsync(loadResult.ProfileLoadWindow, processName);
+            if (!result.Success) {
+                await CloseProfileLoadWindowAsync(loadResult.ProfileLoadWindow);
+            }
+
+            return result;
         }
         catch (Exception ex) {
             return new OpenTraceResult {
@@ -287,6 +339,22 @@ public class McpActionExecutor : IMcpActionExecutor
         return (true, profileLoadWindow, null);
     }
 
+    private async Task CloseProfileLoadWindowAsync(ProfileExplorer.UI.ProfileLoadWindow profileLoadWindow)
+    {
+        if (profileLoadWindow == null)
+        {
+            return;
+        }
+
+        await dispatcher.InvokeAsync(() =>
+        {
+            if (profileLoadWindow.IsVisible)
+            {
+                profileLoadWindow.Close();
+            }
+        });
+    }
+
     private async Task<OpenTraceResult> SelectProcessByPidAsync(ProfileExplorer.UI.ProfileLoadWindow profileLoadWindow, int processId) {
         // Step 5: Select the specified process from the process list
         // Use retry logic in case there are still brief timing issues
@@ -345,17 +413,15 @@ public class McpActionExecutor : IMcpActionExecutor
                 ErrorMessage = $"Process with ID {processId} not found in trace file",
             };
         }
-        
+
+        await EnsureMainWindowReadyAsync();
+
         // Step 6: Execute the profile load (click Load button)
-        await dispatcher.InvokeAsync(() =>
+        var loadClickResult = await InvokeLoadButtonClickAsync(profileLoadWindow);
+        if (!loadClickResult.Success)
         {
-            var loadButtonClickMethod = profileLoadWindow.GetType().GetMethod("LoadButton_Click", 
-                BindingFlags.NonPublic | BindingFlags.Instance);
-            if (loadButtonClickMethod != null)
-            {
-                loadButtonClickMethod.Invoke(profileLoadWindow, new object[] { profileLoadWindow, new RoutedEventArgs() });
-            }
-        });
+            return loadClickResult;
+        }
         
         // Step 7: Wait for the profile to finish loading
         bool profileLoadCompleted = await WaitForProfileLoadingCompletedAsync(profileLoadWindow, TimeSpan.FromMinutes(30));
@@ -437,14 +503,13 @@ public class McpActionExecutor : IMcpActionExecutor
             };
         }
 
+        await EnsureMainWindowReadyAsync();
+
         // Step 6: Execute the profile load (click Load button)
-        await dispatcher.InvokeAsync(() => {
-            var loadButtonClickMethod = profileLoadWindow.GetType().GetMethod("LoadButton_Click",
-                BindingFlags.NonPublic | BindingFlags.Instance);
-            if (loadButtonClickMethod != null) {
-                loadButtonClickMethod.Invoke(profileLoadWindow, new object[] { profileLoadWindow, new RoutedEventArgs() });
-            }
-        });
+        var loadClickResult = await InvokeLoadButtonClickAsync(profileLoadWindow);
+        if (!loadClickResult.Success) {
+            return loadClickResult;
+        }
 
         // Step 7: Wait for the profile to finish loading
         bool profileLoadCompleted = await WaitForProfileLoadingCompletedAsync(profileLoadWindow, TimeSpan.FromMinutes(30));
@@ -461,6 +526,32 @@ public class McpActionExecutor : IMcpActionExecutor
         return new OpenTraceResult { Success = true };
     }
 
+    private async Task<OpenTraceResult> InvokeLoadButtonClickAsync(ProfileExplorer.UI.ProfileLoadWindow profileLoadWindow)
+    {
+        OpenTraceResult errorResult = null;
+
+        await dispatcher.InvokeAsync(() =>
+        {
+            var loadButtonClickMethod = profileLoadWindow.GetType().GetMethod("LoadButton_Click",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+
+            if (loadButtonClickMethod == null)
+            {
+                errorResult = new OpenTraceResult
+                {
+                    Success = false,
+                    FailureReason = OpenTraceFailureReason.UIError,
+                    ErrorMessage = "Failed to find profile load action."
+                };
+                return;
+            }
+
+            loadButtonClickMethod.Invoke(profileLoadWindow, new object[] { profileLoadWindow, new RoutedEventArgs() });
+        });
+
+        return errorResult ?? new OpenTraceResult { Success = true };
+    }
+
     /// <summary>
     /// Waits for a window of type T to appear, with a timeout.
     /// </summary>
@@ -470,8 +561,8 @@ public class McpActionExecutor : IMcpActionExecutor
         
         while (DateTime.UtcNow - startTime < timeout)
         {
-            var window = await dispatcher.InvokeAsync(() => 
-                mainWindow.OwnedWindows.OfType<T>().FirstOrDefault());
+            var window = await dispatcher.InvokeAsync(() =>
+                Application.Current.Windows.OfType<T>().FirstOrDefault(window => window.IsVisible));
             
             if (window != null)
             {

--- a/src/ProfileExplorerUI/Mcp/McpActionExecutor.cs
+++ b/src/ProfileExplorerUI/Mcp/McpActionExecutor.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
@@ -37,7 +38,6 @@ public class McpActionExecutor : IMcpActionExecutor
         // Mark that MCP automation is active - suppress UI dialogs
         App.SuppressDialogsForAutomation = true;
 
-        // Validate file exists first
         if (!File.Exists(profileFilePath))
         {
             return new OpenTraceResult
@@ -48,14 +48,32 @@ public class McpActionExecutor : IMcpActionExecutor
             };
         }
 
-        // Check if the requested trace and process is already loaded
-        var alreadyLoadedResult = await CheckIfTraceAlreadyLoadedAsync(profileFilePath, processIdentifier);
-        if (alreadyLoadedResult != null)
+        // Strict precondition: a profile must not already be loaded. Caller is
+        // expected to invoke close_trace first. This also avoids the silent
+        // no-op from LoadProfile.CanExecute (MainWindowProfiling.cs:577 —
+        // !IsSessionStarted || ProfileData == null) when a profile is loaded.
+        var existingProfile = await GetLoadedProfileSummaryAsync();
+        if (existingProfile != null)
         {
-            return alreadyLoadedResult;
+            return new OpenTraceResult
+            {
+                Success = false,
+                FailureReason = OpenTraceFailureReason.TraceAlreadyLoaded,
+                ErrorMessage = $"A trace is already loaded ('{existingProfile.Value.tracePath}', " +
+                               $"PID {existingProfile.Value.processId}). Call close_trace before open_trace."
+            };
         }
 
-        // Try to parse as a process ID first
+        // In --mcp mode the MainWindow was created hidden; show it now that we're
+        // about to load and display a trace.
+        await dispatcher.InvokeAsync(() =>
+        {
+            if (!mainWindow.IsVisible)
+            {
+                mainWindow.Show();
+            }
+        });
+
         if (int.TryParse(processIdentifier, out int processId))
         {
             if (processId <= 0)
@@ -1986,5 +2004,72 @@ public class McpActionExecutor : IMcpActionExecutor
         {
             return null;
         }
+    }
+
+    public async Task<CloseTraceResult> CloseTraceAsync()
+    {
+        try
+        {
+            var loaded = await GetLoadedProfileSummaryAsync();
+            if (loaded == null)
+            {
+                return new CloseTraceResult
+                {
+                    Success = true,
+                    WasLoaded = false
+                };
+            }
+
+            // Drive the close on the UI thread. dispatcher.InvokeAsync(Func<Task>) returns a
+            // DispatcherOperation<Task>; awaiting only that DispatcherOperation would surface
+            // the inner Task without awaiting it ("Task<Task>" trap). Use .Task.Unwrap() so
+            // the await actually blocks until CloseSessionAsync completes.
+            await dispatcher
+                .InvokeAsync(() => mainWindow.CloseSessionAsync())
+                .Task
+                .Unwrap();
+
+            return new CloseTraceResult
+            {
+                Success = true,
+                WasLoaded = true,
+                ClosedProfilePath = loaded.Value.tracePath,
+                ClosedProcessId = loaded.Value.processId,
+                ClosedProcessName = loaded.Value.processName
+            };
+        }
+        catch (Exception ex)
+        {
+            return new CloseTraceResult
+            {
+                Success = false,
+                FailureReason = CloseTraceFailureReason.UnknownError,
+                ErrorMessage = $"Unexpected error closing trace: {ex.Message}"
+            };
+        }
+    }
+
+    /// <summary>
+    /// Returns identifying details of the currently loaded profile session, or null when
+    /// no profile is loaded. Reads via the dispatcher because it touches MainWindow state.
+    /// </summary>
+    private async Task<(string? tracePath, int? processId, string? processName)?> GetLoadedProfileSummaryAsync()
+    {
+        return await dispatcher.InvokeAsync(() =>
+        {
+            var sessionState = mainWindow.SessionState;
+            var profileData = sessionState?.ProfileData;
+            var report = profileData?.Report;
+
+            if (report == null)
+            {
+                return ((string? tracePath, int? processId, string? processName)?)null;
+            }
+
+            string? tracePath = report.TraceInfo?.TraceFilePath;
+            int? processId = report.Process?.ProcessId;
+            string? processName = report.Process?.Name;
+            return (tracePath, processId, processName);
+        });
     }
 }

--- a/src/ProfileExplorerUI/Session/SessionStateManager.cs
+++ b/src/ProfileExplorerUI/Session/SessionStateManager.cs
@@ -364,6 +364,10 @@ public class SessionStateManager : IDisposable {
 
     documents_.Clear();
     IsAutoSaveEnabled = false;
+
+    // Required so MainWindow.LoadProfile.CanExecute (checks ProfileData == null)
+    // re-enables and the MCP "is profile loaded" probe goes false after a close.
+    ProfileData = null;
   }
 
   public async Task CancelPendingTasks() {


### PR DESCRIPTION
Three small, related additions to the MCP integration so AI agents can drive ProfileExplorer across multiple traces in one agent session.

What

 - close_trace MCP tool — releases the currently loaded trace and frees its resources. Idempotent: returns Success=true, WasLoaded=false when no trace is loaded.
 - Strict open_trace precondition — fails with TraceAlreadyLoaded if a trace is not closed yet. Agents must call close_trace first. Replaces the previous silent no-op when LoadProfile.CanExecute is false.
 - --mcp CLI flag — when launched with --mcp, ProfileExplorer initializes the MCP server, suppresses dialogs, and stays headless. The window only appears on the first successful open_trace. Without the flag, behavior is unchanged.

Why

Previously the MCP open_trace tool could only be called once per UI session — there was no way to release a trace, and re-opening silently no-op'd. The --mcp flag avoids a window popping up every time an agent host spawns a stdio MCP child.

Notes

 - EndSession and other master code paths are unchanged. New behavior is added via a thin CloseSessionAsync wrapper and a single ProfileData = null reset so LoadProfile.CanExecute re-enables and the MCP "is loaded" probe goes false.
 - OpenTraceFailureReason.TraceAlreadyLoaded appended at end of enum to preserve numeric values.
 - OpenTraceResult public shape preserved (existing AlreadyLoaded/Message fields kept).
 - Reviewed cross-family (GPT-5.5); 2 cleanups applied (CS8632 annotations, unused using)