### PR TITLE
Resolve x64 RIP-relative IAT operands in disassembly

### DIFF
--- a/src/ProfileExplorer.McpServer/ProfileExplorer.McpServer.csproj
+++ b/src/ProfileExplorer.McpServer/ProfileExplorer.McpServer.csproj
@@ -19,4 +19,20 @@
     <ProjectReference Include="..\ProfileExplorerCore\ProfileExplorerCore.csproj" />
   </ItemGroup>
 
+  <!--
+    Copy native dependencies (capstone, msdia, etc.) to the output folder.
+    These are required at runtime by Disassembler (capstone.dll) and the PDB
+    debug info provider (msdia140.dll). They live in src\external and are
+    built/staged by build.cmd / build-external.cmd.
+  -->
+  <ItemGroup>
+    <NativeDependency Include="..\external\capstone\build\Release\capstone.dll" Condition="Exists('..\external\capstone\build\Release\capstone.dll')" />
+    <NativeDependency Include="..\external\msdia140.dll" Condition="Exists('..\external\msdia140.dll')" />
+    <NativeDependency Include="..\external\tree-sitter\build\*.dll" />
+  </ItemGroup>
+
+  <Target Name="CopyNativeDependencies" AfterTargets="Build" Inputs="@(NativeDependency)" Outputs="@(NativeDependency -> '$(OutputPath)%(Filename)%(Extension)')">
+    <Copy SourceFiles="@(NativeDependency)" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" />
+  </Target>
+
 </Project>

--- a/src/ProfileExplorer.McpServer/Program.cs
+++ b/src/ProfileExplorer.McpServer/Program.cs
@@ -168,9 +168,11 @@ public static class ProfileTools
     [Description("Process name or ID. A name like 'diskspd' selects ALL matching processes. Comma-separated IDs (e.g. '9492,9500') select specific ones.")]
     string processNameOrId,
     [Description("Optional additional symbol search path (e.g. 'd:\\temp\\landy' for custom kernel symbols)")]
-    string? symbolPath = null)
+    string? symbolPath = null,
+    [Description("Optional additional binary search path (e.g. 'd:\\temp' for loose binaries like storport.sys). Required for assembly-level disassembly via GetFunctionAssembly when the binary isn't on the symbol server.")]
+    string? binaryPath = null)
   {
-    DiagnosticLogger.LogInfo($"[MCP] OpenTrace called: profileFilePath={profileFilePath}, processNameOrId={processNameOrId}, symbolPath={symbolPath ?? "(none)"}");
+    DiagnosticLogger.LogInfo($"[MCP] OpenTrace called: profileFilePath={profileFilePath}, processNameOrId={processNameOrId}, symbolPath={symbolPath ?? "(none)"}, binaryPath={binaryPath ?? "(none)"}");
 
     if (!File.Exists(profileFilePath))
       return Error("OpenTrace", $"File not found: {profileFilePath}");
@@ -197,10 +199,16 @@ public static class ProfileTools
         symbolSettings.UseEnvironmentVarSymbolPaths = true;
         if (!string.IsNullOrWhiteSpace(symbolPath))
           symbolSettings.InsertSymbolPath(symbolPath);
+        if (!string.IsNullOrWhiteSpace(binaryPath))
+        {
+          options.BinarySearchPathsEnabled = true;
+          options.InsertBinaryPath(binaryPath);
+        }
         ProfileSession.SymbolSettings = symbolSettings;
 
         DiagnosticLogger.LogInfo($"[MCP] SymbolSettings: UseEnvVar=true, CustomPath={symbolPath ?? "(none)"}, EnvVar={symbolSettings.EnvironmentVarSymbolPath ?? "(not set)"}");
         DiagnosticLogger.LogInfo($"[MCP] SymbolPaths: {string.Join("; ", symbolSettings.SymbolPaths)}");
+        DiagnosticLogger.LogInfo($"[MCP] BinarySearchPaths: {(options.HasBinarySearchPaths ? string.Join("; ", options.BinarySearchPaths) : "(none)")}");
 
         var report = new ProfileDataReport();
         var provider = new ETWProfileDataProvider();
@@ -529,6 +537,7 @@ public static class ProfileTools
       }
       catch (Exception ex)
       {
+        DiagnosticLogger.LogError($"[MCP] Disassembly failed for {functionName}: {ex.Message}", ex);
         Trace.TraceError($"Disassembly failed for {functionName}: {ex.Message}");
       }
     }

--- a/src/ProfileExplorerCore/Binary/Disassembler.cs
+++ b/src/ProfileExplorerCore/Binary/Disassembler.cs
@@ -115,6 +115,10 @@ public class Disassembler : IDisposable {
   public void UseSymbolNameResolver(SymbolNameResolverDelegate symbolNameResolver) {
     symbolNameResolver_ = symbolNameResolver;
     checkValidCallAddress_ = false;
+    // IAT-slot name resolution is cached per-instance; invalidate the cache so
+    // disabling/swapping the resolver takes effect immediately for subsequent
+    // disassembly calls.
+    iatSymbolCache_?.Clear();
   }
 
   public string DisassembleToText(FunctionDebugInfo funcInfo) {

--- a/src/ProfileExplorerCore/Binary/Disassembler.cs
+++ b/src/ProfileExplorerCore/Binary/Disassembler.cs
@@ -71,6 +71,7 @@ public class Disassembler : IDisposable {
   private SymbolNameResolverDelegate symbolNameResolver_;
   private FunctionNameFormatter funcNameFormatter_;
   private object sectionLock_;
+  private Dictionary<long, string> iatSymbolCache_;
 
   private Disassembler(Machine architecture,
                        PEBinaryInfoProvider peInfo,
@@ -206,7 +207,18 @@ public class Disassembler : IDisposable {
         long hexValue = 0;
 
         if (letter == '[') {
-          sawBracket = true; // Reject lookups for call ptr [rip + 0xABCD] and similar.
+          // For x64, try to resolve RIP-relative [rip + 0xN] / [rip - 0xN]
+          // memory operands, which are typically IAT slots for indirect
+          // calls/jumps through imported functions. The PDB has public
+          // symbols (e.g., _imp_FunctionName) at these slot addresses.
+          if (architecture_ == Machine.Amd64 && !sawBracket &&
+              TryResolveRipRelativeOperand(instr, letterPtr, index, builder,
+                                           out int consumedLength)) {
+            index += consumedLength;
+            continue;
+          }
+
+          sawBracket = true; // Reject lookups for call ptr [rax + 0xN] and similar.
         }
         else if (letter == '#' && isArm && !sawBracket) {
           hexLength = FindHexNumber(letterPtr, index + 1, out hexValue); // Skip over #
@@ -289,6 +301,139 @@ public class Disassembler : IDisposable {
     }
 
     return null;
+  }
+
+  // Attempt to detect and resolve an x64 RIP-relative memory operand of the
+  // form "[rip + 0xN]" or "[rip - 0xN]" (and the rare "[rip]"). On success,
+  // appends "[symbol]" to the builder and returns true with consumedLength
+  // set to the number of characters that should be skipped in the operand
+  // text (including the leading '[' and trailing ']'). On failure leaves the
+  // builder unchanged and returns false.
+  private unsafe bool TryResolveRipRelativeOperand(Interop.Instruction instr, byte* letterPtr,
+                                                   int startIdx, StringBuilder builder,
+                                                   out int consumedLength) {
+    consumedLength = 0;
+
+    if (letterPtr[startIdx] != (byte)'[') {
+      return false;
+    }
+
+    int idx = startIdx + 1;
+    SkipOperandWhitespace(letterPtr, ref idx);
+
+    // Match "rip".
+    if (idx + 2 >= Interop.Instruction.OperandLength ||
+        letterPtr[idx] != (byte)'r' ||
+        letterPtr[idx + 1] != (byte)'i' ||
+        letterPtr[idx + 2] != (byte)'p') {
+      return false;
+    }
+
+    idx += 3;
+    SkipOperandWhitespace(letterPtr, ref idx);
+
+    long signedOffset = 0;
+
+    if (idx < Interop.Instruction.OperandLength && letterPtr[idx] == (byte)']') {
+      // Bare [rip] with no displacement.
+      idx++;
+    }
+    else {
+      // Expect + or -, then a hex number, then ].
+      int sign;
+
+      if (idx >= Interop.Instruction.OperandLength) {
+        return false;
+      }
+
+      if (letterPtr[idx] == (byte)'+') {
+        sign = 1;
+      }
+      else if (letterPtr[idx] == (byte)'-') {
+        sign = -1;
+      }
+      else {
+        return false;
+      }
+
+      idx++;
+      SkipOperandWhitespace(letterPtr, ref idx);
+
+      int hexLen = FindHexNumber(letterPtr, idx, out long hexValue);
+
+      if (hexLen <= 0) {
+        return false;
+      }
+
+      idx += hexLen;
+      signedOffset = sign * hexValue;
+      SkipOperandWhitespace(letterPtr, ref idx);
+
+      if (idx >= Interop.Instruction.OperandLength || letterPtr[idx] != (byte)']') {
+        return false;
+      }
+
+      idx++;
+    }
+
+    // Resolve the target. For RIP-relative addressing the effective address is
+    // (next-instruction address) + displacement, i.e. instr.Address + instr.Size + disp.
+    long iatSlotAddr = instr.Address + instr.Size + signedOffset;
+    long iatSlotRva = iatSlotAddr - baseAddress_;
+
+    string symbolName = TryResolveIatSlotSymbol(iatSlotRva);
+
+    if (string.IsNullOrEmpty(symbolName)) {
+      return false;
+    }
+
+    builder.Append('[');
+
+    if (funcNameFormatter_ != null) {
+      builder.Append(funcNameFormatter_(symbolName));
+    }
+    else {
+      builder.Append(symbolName);
+    }
+
+    builder.Append(']');
+    consumedLength = idx - startIdx;
+    return true;
+  }
+
+  // Look up a symbol at an exact RVA, intended for IAT slot resolution.
+  // Mirrors TryAppendFunctionName's resolver semantics: if symbolNameResolver_
+  // is set, only consult it (do not fall through to debugInfo_). For the
+  // debugInfo_ path, require an exact RVA match so we don't accidentally
+  // report a nearby function/symbol as if it were the IAT entry.
+  private string TryResolveIatSlotSymbol(long rva) {
+    iatSymbolCache_ ??= new Dictionary<long, string>();
+
+    if (iatSymbolCache_.TryGetValue(rva, out string cached)) {
+      return cached;
+    }
+
+    string name = null;
+
+    if (symbolNameResolver_ != null) {
+      name = symbolNameResolver_(rva);
+    }
+    else if (debugInfo_ != null) {
+      var funcInfo = FindFunctionByRva(rva);
+
+      if (funcInfo != null && funcInfo.StartRVA == rva) {
+        name = funcInfo.Name;
+      }
+    }
+
+    iatSymbolCache_[rva] = name;
+    return name;
+  }
+
+  private static unsafe void SkipOperandWhitespace(byte* letterPtr, ref int idx) {
+    while (idx < Interop.Instruction.OperandLength && letterPtr[idx] == (byte)' ') {
+      idx++;
+    }
   }
 
   private bool ShouldLookupAddressByName(Interop.Instruction instr, ref bool isJump) {


### PR DESCRIPTION
## Summary

Three related changes that together make assembly-level analysis through both the UI and the headless MCP server actually useful for indirect calls and for non-symbol-server binaries.

### 1. Resolve x64 RIP-relative IAT operands in disassembly

The `Disassembler` previously skipped any operand starting with `[`, which meant call/jmp through the import address table displayed as `call qword ptr [rip + 0xN]` instead of a symbolic name. WinDbg resolves these because PDBs contain public symbols (`_imp_*`) at IAT slot addresses; Profile Explorer just wasn't looking them up.

This change detects `[rip +/- 0xN]` (and bare `[rip]`) in operand text, computes the effective RVA, and queries `debugInfo_.FindFunctionByRVA` with an exact-RVA match. On a hit, the operand becomes `[_imp_FunctionName]` (parser-safe bare-symbol form). On a miss, the operand text falls through to the original `[rip + 0xN]` form.

#### Before vs After

Hot spot in `storport!NvmeCompletionDpcRoutine`:

| Before | After |
|---|---|
| `call qword ptr [rip + 0x11ebaf]` | `call qword ptr [__imp_IofCompleteRequest]` |

#### Design notes
- Gated to `Machine.Amd64`. x86 doesn't use RIP-relative; ARM/ARM64 use different patterns.
- Respects existing `ResolveCallTargetNames = false` semantics by routing through `symbolNameResolver_` when set.
- Format `[symbol]` chosen over WinDbg `[module!symbol]` because `ASMParser.ParseIndirection` doesn't handle `!` inside `[]`. The bare form lets the IR layer treat the operand as a normal clickable symbol.
- Exact RVA match required so we don't mis-label a nearby symbol as the IAT entry when the PDB lacks `_imp_*` entries.
- Resolved names cached per-`Disassembler` instance so repeated IAT calls in large functions don't hammer DIA.

### 2. McpServer: `binaryPath` parameter on `OpenTrace`

`OpenTrace` already accepted `symbolPath` for PDB search but had no equivalent for binary search. When a trace referenced a private or custom-built binary that isn't on the symbol server (e.g. a loose `storport.sys` in `d:\temp`), `DisassembleFunctionAsync` would fail and `GetFunctionAssembly` would return `HasDisassembly: false`.

Added an optional `binaryPath` parameter that injects into `ProfileDataProviderOptions.BinarySearchPaths`. `LoadTraceAsync` already merges those into `SymbolFileSourceSettings.SymbolPaths`, so `PEBinaryInfoProvider.FindMatchingLocalBinaryFile` picks up the directory automatically. Backward compatible — omitting `binaryPath` continues to work identically (binary will be located from the symbol server cache or downloaded on demand).

### 3. McpServer: copy native dependencies on build

The McpServer's csproj never copied `capstone.dll` (or the other native dependencies from `src/external/`) to its output folder. `build.cmd` does this for the WPF app but the McpServer's csproj had no equivalent. Result: `DisassembleFunctionAsync` threw "Unable to load DLL capstone.dll" at runtime and returned null, silently producing `HasDisassembly: false` responses.

Added an `AfterTargets="Build"` MSBuild target that copies `capstone.dll`, `msdia140.dll`, and the tree-sitter DLLs from `src/external/` (when present — they're staged by `build.cmd` / `build-external.cmd`) into the McpServer's output directory.

## Testing

Validated against a multi-process diskspd kernel ETL trace:

**Via the UI**: `NvmeCompletionDpcRoutine` IAT call now shows `call qword ptr [__imp_IofCompleteRequest]` (was `call qword ptr [rip + 0x11ebaf]`).

**Via the MCP** (`GetFunctionAssembly`), with and without `binaryPath`:
- `HasDisassembly: true` (was `false` before fix #3)
- Direct calls resolved: `call StorpTelemetryCollectNvmePerfData`, `call NvmeControllerGetNamespace`
- Source line mapping intact with full inlinee chain (e.g., `NvmeNamespaceIsAlwaysActive` -> `NvmeIdleNamespace` -> `NvmeCompleteIoRequest`)
- Backward compat: omitting `binaryPath` still works when the binary is in the symbol server cache
